### PR TITLE
Allow transferItem to push to multiple slots

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
@@ -183,7 +183,9 @@ public class ModularContainer extends Container {
                 } else {
                     slot.putStack(stack.splitStack(stack.stackSize));
                 }
-                break;
+                if (stack.stackSize < 1) {
+                    break;
+                }
             }
         }
         return stack;


### PR DESCRIPTION
In some situations, the slot stack size may be limited. Shift clicking a full stack can require multiple slots to be filled; this change adds a check for whether the slot can continue to be transferred.