### PR TITLE
Fix the broken isSlotInInventory method for 1.7 modular Slots

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/future/IItemHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/future/IItemHandler.java
@@ -116,4 +116,15 @@ public interface IItemHandler {
         }
         return ret;
     }
+
+    /**
+     * Checks if the given slot index corresponds to the given slot in an IInventory.
+     * @param index The index of the slot in this item handler.
+     * @param inventory The Minecraft inventory to check for correspondence.
+     * @param invIndex The index of the slot in the Minecraft inventory to check.
+     * @return True if index in this and invIndex in inventory point to the same slot.
+     */
+    default boolean isSlotFromInventory(int index, IInventory inventory, int invIndex) {
+        return false;
+    }
 }

--- a/src/main/java/com/cleanroommc/modularui/future/InvWrapper.java
+++ b/src/main/java/com/cleanroommc/modularui/future/InvWrapper.java
@@ -144,4 +144,9 @@ public class InvWrapper implements IItemHandlerModifiable {
     public IInventory getInv() {
         return inv;
     }
+
+    @Override
+    public boolean isSlotFromInventory(int index, IInventory inventory, int invIndex) {
+        return inventory == this.inv && index == invIndex && invIndex >= 0 && invIndex < inv.getSizeInventory();
+    }
 }

--- a/src/main/java/com/cleanroommc/modularui/future/RangedWrapper.java
+++ b/src/main/java/com/cleanroommc/modularui/future/RangedWrapper.java
@@ -2,6 +2,7 @@ package com.cleanroommc.modularui.future;
 
 import com.google.common.base.Preconditions;
 
+import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 
 /**
@@ -84,5 +85,10 @@ public class RangedWrapper implements IItemHandlerModifiable {
 
     public IItemHandlerModifiable getCompose() {
         return compose;
+    }
+
+    @Override
+    public boolean isSlotFromInventory(int index, IInventory inventory, int invIndex) {
+        return compose.isSlotFromInventory(index + minSlot, inventory, invIndex);
     }
 }

--- a/src/main/java/com/cleanroommc/modularui/future/SlotItemHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/future/SlotItemHandler.java
@@ -104,4 +104,9 @@ public class SlotItemHandler extends Slot {
     public boolean isSameInventory(Slot other) {
         return other instanceof SlotItemHandler slotHand && slotHand.getItemHandler() == this.itemHandler;
     }
+
+    @Override
+    public boolean isSlotInInventory(IInventory inventory, int invIndex) {
+        return itemHandler.isSlotFromInventory(this.index, inventory, invIndex);
+    }
 }


### PR DESCRIPTION
`isSlotFromInventory` always returned false for MUI2 slots, this fixes it to correctly return true for the player and other wrapped inventories.