### PR TITLE
Fix open and close listener behaviour to work as expected

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -108,8 +108,14 @@ minimizeShadowedDependencies = true
 # If disabled, won't rename the shadowed classes.
 relocateShadowedDependencies = true
 
-# Adds the GTNH maven, CurseMaven, Modrinth, and some more well-known 1.7.10 repositories.
+# Adds CurseMaven, Modrinth, and some more well-known 1.7.10 repositories.
 includeWellKnownRepositories = true
+
+# A list of repositories to exclude from the includeWellKnownRepositories setting. Should be a space separated
+# list of strings, with the acceptable keys being(case does not matter):
+# cursemaven
+# modrinth
+excludeWellKnownRepositories =
 
 # Change these to your Maven coordinates if you want to publish to a custom Maven repository instead of the default GTNH Maven.
 # Authenticate with the MAVEN_USER and MAVEN_PASSWORD environment variables.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.21'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.24'
 }
 
 

--- a/src/main/java/com/cleanroommc/modularui/CommonProxy.java
+++ b/src/main/java/com/cleanroommc/modularui/CommonProxy.java
@@ -64,14 +64,4 @@ public class CommonProxy {
             ModularUIConfig.syncConfig();
         }
     }
-
-    @SubscribeEvent
-    public final void onCloseContainer(PlayerOpenContainerEvent event) {
-        if (event.entityPlayer.openContainer instanceof ModularContainer container) {
-            GuiSyncManager syncManager = container.getSyncManager();
-            if (syncManager != null) {
-                syncManager.onOpen();
-            }
-        }
-    }
 }

--- a/src/main/java/com/cleanroommc/modularui/factory/GuiManager.java
+++ b/src/main/java/com/cleanroommc/modularui/factory/GuiManager.java
@@ -96,6 +96,7 @@ public class GuiManager {
         guiScreenWrapper.inventorySlots.windowId = windowId;
         Minecraft.getMinecraft().displayGuiScreen(guiScreenWrapper);
         player.openContainer = guiScreenWrapper.inventorySlots;
+        syncManager.onOpen();
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
@@ -15,6 +15,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;
+import net.minecraft.inventory.ICrafting;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -60,6 +61,14 @@ public class ModularContainer extends Container {
 
     public ContainerAccessor acc() {
         return (ContainerAccessor) this;
+    }
+
+    @Override
+    public void addCraftingToCrafters(ICrafting player) {
+        super.addCraftingToCrafters(player);
+        if (guiSyncManager != null) {
+            guiSyncManager.onOpen();
+        }
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/modularui/test/TestTile.java
+++ b/src/main/java/com/cleanroommc/modularui/test/TestTile.java
@@ -47,6 +47,8 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.fluids.FluidTank;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.atomic.AtomicReference;
@@ -54,6 +56,7 @@ import java.util.function.Function;
 
 public class TestTile extends TileEntity implements IGuiHolder<PosGuiData> {
 
+    private static final Logger LOGGER = LogManager.getLogger("MUI2-Test");
     private final FluidTank fluidTank = new FluidTank(10000);
     private final FluidTank fluidTankPhantom = new FluidTank(Integer.MAX_VALUE);
     private long time = 0;
@@ -81,6 +84,12 @@ public class TestTile extends TileEntity implements IGuiHolder<PosGuiData> {
 
     @Override
     public ModularPanel buildUI(PosGuiData guiData, GuiSyncManager guiSyncManager) {
+        guiSyncManager.addOpenListener(player -> {
+            LOGGER.info("Test Tile panel open by {} on {}", player.getGameProfile().getName(), Thread.currentThread().getName());
+        });
+        guiSyncManager.addCloseListener(player -> {
+            LOGGER.info("Test Tile panel closed by {} on {}", player.getGameProfile().getName(), Thread.currentThread().getName());
+        });
         guiSyncManager.registerSlotGroup("item_inv", 3);
         guiSyncManager.registerSlotGroup("mixer_items", 2);
 

--- a/src/main/java/com/cleanroommc/modularui/value/sync/GuiSyncManager.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/GuiSyncManager.java
@@ -177,11 +177,19 @@ public class GuiSyncManager {
         return registerSlotGroup(new SlotGroup(name, rowSize, 100, true));
     }
 
+    /**
+     * @param listener The function to run whenever the gui {@link net.minecraft.inventory.Container} is open, ran on both the server and client threads.
+     * @return {@code this} for chaining
+     */
     public GuiSyncManager addOpenListener(Consumer<EntityPlayer> listener) {
         this.openListener.add(listener);
         return this;
     }
 
+    /**
+     * @param listener The function to run whenever the gui {@link net.minecraft.inventory.Container} is closed, ran on both the server and client threads.
+     * @return {@code this} for chaining
+     */
     public GuiSyncManager addCloseListener(Consumer<EntityPlayer> listener) {
         this.closeListener.add(listener);
         return this;


### PR DESCRIPTION
Previously open listener would invoke every tick on the server thread and close listener would invoke once on both client&server threads. With this PR it invokes both listeners once on both threads. (Running on both threads is intended as indicated by brachy, I documented this in javadocs)