### PR TITLE
Use ForgeDirection instead of EnumFacing

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/factory/SidedPosGuiData.java
+++ b/src/main/java/com/cleanroommc/modularui/factory/SidedPosGuiData.java
@@ -1,18 +1,18 @@
 package com.cleanroommc.modularui.factory;
 
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.util.ForgeDirection;
 
 public class SidedPosGuiData extends PosGuiData {
 
-    private final EnumFacing side;
+    private final ForgeDirection side;
 
-    public SidedPosGuiData(EntityPlayer player, int x, int y, int z, EnumFacing side) {
+    public SidedPosGuiData(EntityPlayer player, int x, int y, int z, ForgeDirection side) {
         super(player, x, y, z);
         this.side = side;
     }
 
-    public EnumFacing getSide() {
+    public ForgeDirection getSide() {
         return this.side;
     }
 }

--- a/src/main/java/com/cleanroommc/modularui/factory/SidedTileEntityGuiFactory.java
+++ b/src/main/java/com/cleanroommc/modularui/factory/SidedTileEntityGuiFactory.java
@@ -5,7 +5,8 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.util.ForgeDirection;
+
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
@@ -14,24 +15,24 @@ public class SidedTileEntityGuiFactory extends AbstractUIFactory<SidedPosGuiData
 
     public static final SidedTileEntityGuiFactory INSTANCE = new SidedTileEntityGuiFactory();
 
-    public static <T extends TileEntity & IGuiHolder<SidedPosGuiData>> void open(EntityPlayer player, T tile, EnumFacing facing) {
+    public static <T extends TileEntity & IGuiHolder<SidedPosGuiData>> void open(EntityPlayer player, T tile, ForgeDirection side) {
         Objects.requireNonNull(player);
         Objects.requireNonNull(tile);
-        Objects.requireNonNull(facing);
+        Objects.requireNonNull(side);
         if (tile.isInvalid()) {
             throw new IllegalArgumentException("Can't open invalid TileEntity GUI!");
         }
         if (player.worldObj != tile.getWorldObj()) {
             throw new IllegalArgumentException("TileEntity must be in same dimension as the player!");
         }
-        SidedPosGuiData data = new SidedPosGuiData(player, tile.xCoord, tile.yCoord, tile.zCoord, facing);
+        SidedPosGuiData data = new SidedPosGuiData(player, tile.xCoord, tile.yCoord, tile.zCoord, side);
         GuiManager.open(INSTANCE, data, (EntityPlayerMP) player);
     }
 
-    public static void open(EntityPlayer player, int x, int y, int z, EnumFacing facing) {
+    public static void open(EntityPlayer player, int x, int y, int z, ForgeDirection side) {
         Objects.requireNonNull(player);
-        Objects.requireNonNull(facing);
-        SidedPosGuiData data = new SidedPosGuiData(player, x, y, z, facing);
+        Objects.requireNonNull(side);
+        SidedPosGuiData data = new SidedPosGuiData(player, x, y, z, side);
         GuiManager.open(INSTANCE, data, (EntityPlayerMP) player);
     }
 
@@ -54,6 +55,6 @@ public class SidedTileEntityGuiFactory extends AbstractUIFactory<SidedPosGuiData
 
     @Override
     public @NotNull SidedPosGuiData readGuiData(EntityPlayer player, PacketBuffer buffer) {
-        return new SidedPosGuiData(player, buffer.readVarIntFromBuffer(), buffer.readVarIntFromBuffer(), buffer.readVarIntFromBuffer(), EnumFacing.values()[buffer.readByte()]);
+        return new SidedPosGuiData(player, buffer.readVarIntFromBuffer(), buffer.readVarIntFromBuffer(), buffer.readVarIntFromBuffer(), ForgeDirection.getOrientation(buffer.readByte()));
     }
 }


### PR DESCRIPTION
ForgeDirection is far more used in 1.7.10 modding scene than EnumFacing. This is technically breaking change, but I haven't seen anyone using these.