### PR TITLE
Small mixin fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -82,7 +82,7 @@ usesMixins = true
 separateMixinSourceSet =
 
 # Adds some debug arguments like verbose output and class export.
-usesMixinDebug = false
+usesMixinDebug = true
 
 # Specify the location of your implementation of IMixinConfigPlugin. Leave it empty otherwise.
 mixinPlugin =

--- a/src/main/java/com/cleanroommc/modularui/drawable/GuiDraw.java
+++ b/src/main/java/com/cleanroommc/modularui/drawable/GuiDraw.java
@@ -329,7 +329,7 @@ public class GuiDraw {
         GL11.glEnable(GL11.GL_DEPTH_TEST);
         GL11.glTranslatef(x, y, 0);
         GL11.glScalef(width / 16f, height / 16f, 1);
-        RenderItem renderItem = ((GuiScreenAccessor) Minecraft.getMinecraft().currentScreen).getItemRender();
+        RenderItem renderItem = GuiScreenAccessor.getItemRender();
         renderItem.zLevel = 200;
         renderItem.renderItemAndEffectIntoGUI(Minecraft.getMinecraft().fontRenderer, Minecraft.getMinecraft().getTextureManager(), item, 0, 0);
         GuiDraw.afterRenderItemAndEffectIntoGUI(item);

--- a/src/main/java/com/cleanroommc/modularui/mixins/early/minecraft/GuiScreenAccessor.java
+++ b/src/main/java/com/cleanroommc/modularui/mixins/early/minecraft/GuiScreenAccessor.java
@@ -36,7 +36,9 @@ public interface GuiScreenAccessor {
     void setLastMouseEvent(long event);
 
     @Accessor
-    RenderItem getItemRender();
+    static RenderItem getItemRender() {
+        throw new UnsupportedOperationException("Mixin failed to inject!");
+    }
 
     @Accessor("fontRendererObj")
     FontRenderer getFontRenderer();

--- a/src/main/java/com/cleanroommc/modularui/screen/ClientScreenHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/ClientScreenHandler.java
@@ -425,16 +425,16 @@ public class ClientScreenHandler {
     private static void drawItemStack(GuiContainer mcScreen, ItemStack stack, int x, int y, String altText) {
         GL11.glTranslatef(0.0F, 0.0F, 32.0F);
         ((GuiAccessor) mcScreen).setZLevel(200f);
-        ((GuiScreenAccessor) mcScreen).getItemRender().zLevel = 200.0F;
+        GuiScreenAccessor.getItemRender().zLevel = 200.0F;
         FontRenderer font = stack.getItem().getFontRenderer(stack);
         if (font == null) font = ((GuiScreenAccessor) mcScreen).getFontRenderer();
         GL11.glEnable(GL11.GL_DEPTH_TEST);
-        ((GuiScreenAccessor) mcScreen).getItemRender().renderItemAndEffectIntoGUI(font, Minecraft.getMinecraft().getTextureManager(), stack, x, y);
+        GuiScreenAccessor.getItemRender().renderItemAndEffectIntoGUI(font, Minecraft.getMinecraft().getTextureManager(), stack, x, y);
         GuiDraw.afterRenderItemAndEffectIntoGUI(stack);
-        ((GuiScreenAccessor) mcScreen).getItemRender().renderItemOverlayIntoGUI(font, Minecraft.getMinecraft().getTextureManager(), stack, x, y - (((GuiContainerAccessor) mcScreen).getDraggedStack() == null ? 0 : 8), altText);
+        GuiScreenAccessor.getItemRender().renderItemOverlayIntoGUI(font, Minecraft.getMinecraft().getTextureManager(), stack, x, y - (((GuiContainerAccessor) mcScreen).getDraggedStack() == null ? 0 : 8), altText);
         GL11.glDisable(GL11.GL_DEPTH_TEST);
         ((GuiAccessor) mcScreen).setZLevel(0f);
-        ((GuiScreenAccessor) mcScreen).getItemRender().zLevel = 0.0F;
+        GuiScreenAccessor.getItemRender().zLevel = 0.0F;
     }
 
     private static void drawVanillaElements(GuiScreen mcScreen, int mouseX, int mouseY, float partialTicks) {

--- a/src/main/java/com/cleanroommc/modularui/widgets/ItemSlot.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/ItemSlot.java
@@ -191,7 +191,7 @@ public class ItemSlot extends Widget<ItemSlot> implements IVanillaSlot, Interact
         if (!(guiScreen instanceof GuiContainer))
             throw new IllegalStateException("The gui must be an instance of GuiContainer if it contains slots!");
         GuiContainerAccessor acc = (GuiContainerAccessor) guiScreen;
-        RenderItem renderItem = ((GuiScreenAccessor) guiScreen).getItemRender();
+        RenderItem renderItem = GuiScreenAccessor.getItemRender();
         ItemStack itemstack = slotIn.getStack();
         boolean flag = false;
         boolean flag1 = slotIn == acc.getClickedSlot() && acc.getDraggedStack() != null && !acc.getIsRightMouseClick();

--- a/src/main/java/com/cleanroommc/modularui/widgets/ItemSlotLong.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/ItemSlotLong.java
@@ -193,7 +193,7 @@ public class ItemSlotLong extends Widget<ItemSlotLong> implements IVanillaSlot, 
         if (!(guiScreen instanceof GuiContainer))
             throw new IllegalStateException("The gui must be an instance of GuiContainer if it contains slots!");
         GuiContainerAccessor acc = (GuiContainerAccessor) guiScreen;
-        RenderItem renderItem = ((GuiScreenAccessor) guiScreen).getItemRender();
+        RenderItem renderItem = GuiScreenAccessor.getItemRender();
         IItemStackLong itemstack = slotIn.getStackLong();
         boolean flag = false;
         boolean flag1 = slotIn == acc.getClickedSlot() && acc.getDraggedStack() != null && !acc.getIsRightMouseClick();


### PR DESCRIPTION
- Activate mixin debug in dev env
- fix : `[mixin]: mixins.modularui2.early.json:minecraft.GuiScreenAccessor from mod modularui2->@Accessor[FIELD_GETTER]::getItemRender()Lnet/minecraft/client/renderer/entity/RenderItem; should be static as its target is`