### PR TITLE
Fix shift click a ModularSlot with ignoreMaxStackSize=true void items

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/screen/ContainerCustomizer.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/ContainerCustomizer.java
@@ -251,7 +251,7 @@ public class ContainerCustomizer {
                     stack.stackSize = stack.getMaxStackSize();
                 }
                 ItemStack remainder = transferItem(slot, stack.copy());
-                if (base == 0 && remainder == null || remainder.stackSize < 1) stack = null;
+                if (base == 0 && (remainder == null || remainder.stackSize < 1)) stack = null;
                 else stack.stackSize = base + remainder.stackSize;
                 slot.putStack(stack);
                 return null;


### PR DESCRIPTION
Before

https://github.com/user-attachments/assets/2548d38d-8a97-4dad-a7bf-eeb9f125bdca

After

https://github.com/user-attachments/assets/ff237e01-3fd1-4712-bf20-1cb7a14697f8

Explained:
When stacksize in slot>64
| expression（at line 254） | value |
| ----------- | ----------- |
| base | stack.stacksize -64 (the part of stacksize that exceeds 64) |
| remainder.stacksize | 0 (originally 64, then all transfered away) |
| (base == 0 && remainder == null or remainder.stackSize < 1)  |  (false&&false or true)=true <---This will void items!|
| (base == 0 &&( remainder == null or remainder.stackSize < 1))  |  (false&&(false or true))=false <---This is correct|
