### PR TITLE
Fix Widget listener merge

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/widget/Widget.java
+++ b/src/main/java/com/cleanroommc/modularui/widget/Widget.java
@@ -317,7 +317,7 @@ public class Widget<W extends Widget<W>> implements IWidget, IPositioned<W>, ITo
 
     public W onUpdateListener(Consumer<W> listener, boolean merge) {
         if (merge && this.onUpdateListener != null) {
-            final Consumer<W> oldListener=this.onUpdateListener;
+            final Consumer<W> oldListener = this.onUpdateListener;
             if (listener != null) {
                 this.onUpdateListener = w -> {
                     oldListener.accept(w);

--- a/src/main/java/com/cleanroommc/modularui/widget/Widget.java
+++ b/src/main/java/com/cleanroommc/modularui/widget/Widget.java
@@ -317,9 +317,10 @@ public class Widget<W extends Widget<W>> implements IWidget, IPositioned<W>, ITo
 
     public W onUpdateListener(Consumer<W> listener, boolean merge) {
         if (merge && this.onUpdateListener != null) {
+            final Consumer<W> oldListener=this.onUpdateListener;
             if (listener != null) {
                 this.onUpdateListener = w -> {
-                    this.onUpdateListener.accept(w);
+                    oldListener.accept(w);
                     listener.accept(w);
                 };
             }


### PR DESCRIPTION
Fix
```
[22:19:59] [Client thread/ERROR] [FML/]: SimpleChannelHandlerWrapper exception
java.lang.StackOverflowError
	at com.cleanroommc.modularui.widget.Widget.lambda$onUpdateListener$0(Widget.java:322) ~[Widget.class:?]
	at com.cleanroommc.modularui.widget.Widget.lambda$onUpdateListener$0(Widget.java:322) ~[Widget.class:?]
	at com.cleanroommc.modularui.widget.Widget.lambda$onUpdateListener$0(Widget.java:322) ~[Widget.class:?]
	at com.cleanroommc.modularui.widget.Widget.lambda$onUpdateListener$0(Widget.java:322) ~[Widget.class:?]
	at com.cleanroommc.modularui.widget.Widget.lambda$onUpdateListener$0(Widget.java:322) ~[Widget.class:?]
	at com.cleanroommc.modularui.widget.Widget.lambda$onUpdateListener$0(Widget.java:322) ~[Widget.class:?]
	at com.cleanroommc.modularui.widget.Widget.lambda$onUpdateListener$0(Widget.java:322) ~[Widget.class:?]
	at com.cleanroommc.modularui.widget.Widget.lambda$onUpdateListener$0(Widget.java:322) ~[Widget.class:?]
	at com.cleanroommc.modularui.widget.Widget.lambda$onUpdateListener$0(Widget.java:322) ~[Widget.class:?]
	at com.cleanroommc.modularui.widget.Widget.lambda$onUpdateListener$0(Widget.java:322) ~[Widget.class:?]
	at com.cleanroommc.modularui.widget.Widget.lambda$onUpdateListener$0(Widget.java:322) ~[Widget.class:?]
	at com.cleanroommc.modularui.widget.Widget.lambda$onUpdateListener$0(Widget.java:322) ~[Widget.class:?]
	at com.cleanroommc.modularui.widget.Widget.lambda$onUpdateListener$0(Widget.java:322) ~[Widget.class:?]
```