### PR TITLE
Allow a phantom FluidSlot on draggable panel to be cleared with clicking

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/widgets/FluidSlot.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/FluidSlot.java
@@ -302,4 +302,9 @@ public class FluidSlot extends Widget<FluidSlot> implements Interactable, NEIDra
         }
         return null;
     }
+
+    @Override
+    public Result onMousePressed(int mouseButton) {
+        return Result.SUCCESS;
+    }
 }

--- a/src/main/java/com/cleanroommc/modularui/widgets/FluidSlot.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/FluidSlot.java
@@ -188,21 +188,20 @@ public class FluidSlot extends Widget<FluidSlot> implements Interactable, NEIDra
         return ITheme.getDefault().getFluidSlotTheme().getSlotHoverColor();
     }
 
-    @NotNull
-    @Override
-    public Result onMouseTapped(int mouseButton) {
-        if (!this.syncHandler.canFillSlot() && !this.syncHandler.canDrainSlot()) {
-            return Result.IGNORE;
-        }
-        ItemStack cursorStack = Minecraft.getMinecraft().thePlayer.inventory.getItemStack();
-        if (this.syncHandler.isPhantom() || cursorStack != null) {
-            MouseData mouseData = MouseData.create(mouseButton);
-            this.syncHandler.syncToServer(1, mouseData::writeToPacket);
-        }
-        return Result.SUCCESS;
-    }
+	@Override
+	public @NotNull Result onMousePressed(int mouseButton) {
+			if (!this.syncHandler.canFillSlot() && !this.syncHandler.canDrainSlot()) {
+				return Result.ACCEPT;
+			}
+			ItemStack cursorStack = Minecraft.getMinecraft().thePlayer.inventory.getItemStack();
+			if (this.syncHandler.isPhantom() || cursorStack != null) {
+				MouseData mouseData = MouseData.create(mouseButton);
+				this.syncHandler.syncToServer(1, mouseData::writeToPacket);
+			}
+		return Result.SUCCESS;
+	}
 
-    @Override
+	@Override
     public boolean onMouseScroll(ModularScreen.UpOrDown scrollDirection, int amount) {
         if (this.syncHandler.isPhantom()) {
             if ((scrollDirection.isUp() && !this.syncHandler.canFillSlot()) || (scrollDirection.isDown() && !this.syncHandler.canDrainSlot())) {
@@ -301,10 +300,5 @@ public class FluidSlot extends Widget<FluidSlot> implements Interactable, NEIDra
             return GTUtility.getFluidDisplayStack(getFluidStack(), false);
         }
         return null;
-    }
-
-    @Override
-    public Result onMousePressed(int mouseButton) {
-        return Result.SUCCESS;
     }
 }

--- a/src/main/java/com/cleanroommc/modularui/widgets/FluidSlot.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/FluidSlot.java
@@ -190,14 +190,14 @@ public class FluidSlot extends Widget<FluidSlot> implements Interactable, NEIDra
 
 	@Override
 	public @NotNull Result onMousePressed(int mouseButton) {
-			if (!this.syncHandler.canFillSlot() && !this.syncHandler.canDrainSlot()) {
-				return Result.ACCEPT;
-			}
-			ItemStack cursorStack = Minecraft.getMinecraft().thePlayer.inventory.getItemStack();
-			if (this.syncHandler.isPhantom() || cursorStack != null) {
-				MouseData mouseData = MouseData.create(mouseButton);
-				this.syncHandler.syncToServer(1, mouseData::writeToPacket);
-			}
+		if (!this.syncHandler.canFillSlot() && !this.syncHandler.canDrainSlot()) {
+			return Result.ACCEPT;
+		}
+		ItemStack cursorStack = Minecraft.getMinecraft().thePlayer.inventory.getItemStack();
+		if (this.syncHandler.isPhantom() || cursorStack != null) {
+			MouseData mouseData = MouseData.create(mouseButton);
+			this.syncHandler.syncToServer(1, mouseData::writeToPacket);
+		}
 		return Result.SUCCESS;
 	}
 


### PR DESCRIPTION
Before PR, click on a phantom FluidSlot will drag the panel.
![y1](https://github.com/user-attachments/assets/698303b9-11ef-47d3-ad8b-d0ac26b51de5)


After PR, click on a phantom FluidSlot will clear the slot.
![y2](https://github.com/user-attachments/assets/7c560973-103a-4749-943c-bd0c60016bdd)


ItemSlot does not have such glitch, and its onMousePressed returns SUCCESS.
FluidSlot has no overridden onMousePressed, so it fallback to the default method in Interactable which returns ACCEPT.

Do not quite know how returning SUCCESS instead of ACCEPT works, but it fixes this issue.