### PR TITLE
Fix clicking slot outside main panel toss the item

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/mixins/early/minecraft/GuiContainerMixin.java
+++ b/src/main/java/com/cleanroommc/modularui/mixins/early/minecraft/GuiContainerMixin.java
@@ -7,11 +7,13 @@ import com.cleanroommc.modularui.screen.IClickableGuiContainer;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.inventory.Slot;
 
+import org.spongepowered.asm.lib.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(GuiContainer.class)
@@ -45,5 +47,17 @@ public class GuiContainerMixin implements IClickableGuiContainer {
     @Override
     public Slot modularUI$getClickedSlot() {
         return modularUI$clickedSlot;
+    }
+	
+	/**
+     * Inject to {@link net.minecraft.client.gui.inventory.GuiContainer#mouseClicked} Line366
+     * Set flag1 to false if a slot is clicked, to fix the bug of tossing item when clicking slot outside the main panel area.
+     * This fix should only applies to 1.7.10, since such bug only appears in 1.7.10.
+     */	
+	@ModifyVariable(
+    method = "mouseClicked",
+    at = @At(value = "FIELD", opcode = Opcodes.GETFIELD, target = "Lnet/minecraft/inventory/Slot;slotNumber:I"),ordinal = 1)
+    protected boolean mouseClickedOnSlot(boolean flag1) {
+		return false;
     }
 }

--- a/src/main/java/com/cleanroommc/modularui/widgets/slot/ItemSlot.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/slot/ItemSlot.java
@@ -23,7 +23,6 @@ import com.cleanroommc.modularui.utils.MouseData;
 import com.cleanroommc.modularui.utils.NumberFormat;
 import com.cleanroommc.modularui.value.sync.ItemSlotSH;
 import com.cleanroommc.modularui.value.sync.SyncHandler;
-import com.cleanroommc.modularui.widget.sizer.Area;
 import com.cleanroommc.modularui.widget.Widget;
 
 import cpw.mods.fml.relauncher.Side;
@@ -129,45 +128,11 @@ public class ItemSlot extends Widget<ItemSlot> implements IVanillaSlot, Interact
         return ITheme.getDefault().getItemSlotTheme().getSlotHoverColor();
     }
 
-	@Override
-	public @NotNull Result onMousePressed(int mouseButton) {
-		Area originalArea = changeGuiArea(getArea());//temporarily set the area of GUI to the area of the slot
-		//or else clicking a slot outside the Area of main panel will toss the item inside the slot
-		//This fix only applies to 1.7.10
-		try{
-			ClientScreenHandler.clickSlot(getScreen(), getSlot());
-		}finally{
-			restoreGuiArea(originalArea);//then restore it
-		}
-		return Result.SUCCESS;
-	}
-
-	private Area changeGuiArea(Area newArea) {
-		GuiScreen guiScreen = getScreen().getScreenWrapper().getGuiScreen();
-		if (!(guiScreen instanceof GuiContainer))
-			throw new IllegalStateException("The gui must be an instance of GuiContainer if it contains slots!");
-		GuiContainerAccessor acc = (GuiContainerAccessor) guiScreen;
-		int oldX = acc.getGuiLeft();
-		int oldY = acc.getGuiTop();
-		int oldW = acc.getXSize();
-		int oldH = acc.getYSize();
-		acc.setGuiLeft(newArea.x());
-		acc.setGuiTop(newArea.y());
-		acc.setXSize(newArea.w());
-		acc.setYSize(newArea.h());
-		return new Area(oldX, oldY, oldW, oldH);
-	}
-
-	private void restoreGuiArea(Area originalArea) {
-		GuiScreen guiScreen = getScreen().getScreenWrapper().getGuiScreen();
-		if (!(guiScreen instanceof GuiContainer))
-			throw new IllegalStateException("The gui must be an instance of GuiContainer if it contains slots!");
-		GuiContainerAccessor acc = (GuiContainerAccessor) guiScreen;
-		acc.setGuiLeft(originalArea.x());
-		acc.setGuiTop(originalArea.y());
-		acc.setXSize(originalArea.w());
-		acc.setYSize(originalArea.h());
-	}
+    @Override
+    public @NotNull Result onMousePressed(int mouseButton) {
+        ClientScreenHandler.clickSlot(getScreen(), getSlot());
+        return Result.SUCCESS;
+    }
 
     @Override
     public boolean onMouseRelease(int mouseButton) {


### PR DESCRIPTION
Try to fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19906

Before

https://github.com/user-attachments/assets/144b896b-2776-4fba-81d0-4bc7548bafc4

After(Tested on both SinglePlayer and Dedicated Server)

https://github.com/user-attachments/assets/fda97f82-cfad-401a-883d-484ac9e6e57c


Cannot reproduce this on 1.12 upstream, so I suppose this this a 1.7.10-only issue.

The problem is
```
net.minecraft.client.gui.inventory.GuiContainer.java 
mouseClicked Line361

boolean flag1 = mouseX < i1 || mouseY < j1 || mouseX >= i1 + this.xSize || mouseY >= j1 + this.ySize;
```
Vanilla GuiContainer only use flag1 to decide whether to toss the item, even if a slot is actually clicked.
So this PR temporarily change the area of main panel to the slot area to workaround.

