### PR TITLE
Readded old constructor for MUI2 widget themes

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/theme/WidgetSlotTheme.java
+++ b/src/main/java/com/cleanroommc/modularui/theme/WidgetSlotTheme.java
@@ -13,8 +13,11 @@ public class WidgetSlotTheme extends WidgetTheme {
     private final IDrawable inventorySlotBackground;
     private final IDrawable hotbarSlotBackground;
 
+    public WidgetSlotTheme(IDrawable background, int slotHoverColor) {
+        this(background, slotHoverColor, false, null, null);
+    }
 
-    public WidgetSlotTheme(IDrawable background, int slotHoverColor,boolean useCustomSlotTextures,IDrawable inventory,IDrawable hotbar) {
+    public WidgetSlotTheme(IDrawable background, int slotHoverColor, boolean useCustomSlotTextures, IDrawable inventory, IDrawable hotbar) {
         super(background, null, Color.WHITE.main, 0xFF404040, false);
         this.slotHoverColor = slotHoverColor;
         this.useCustomSlotTextures=useCustomSlotTextures;


### PR DESCRIPTION
The newly added themes support for widgets (https://github.com/GTNewHorizons/ModularUI2/pull/40) has replaced the old constructor in WidgetSlotTheme. This causes a crash when other mods still look for the old one. Eg. GT5u, which still uses the old constructor as shown here:

<img width="840" height="284" alt="image" src="https://github.com/user-attachments/assets/f7f37e02-4aef-4117-9b8f-fcbef578416f" />


I readded the old constructor for backwards compatibility. This should not affect the widget themes behaviour as it defaults to the fallbacks depending on the slot type when the nulls are passed in.