### PR TITLE
Fix fluid icon null causing a crash

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/drawable/GuiDraw.java
+++ b/src/main/java/com/cleanroommc/modularui/drawable/GuiDraw.java
@@ -33,9 +33,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 import org.lwjgl.opengl.GL11;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Consumer;
 
 public class GuiDraw {
@@ -324,18 +322,14 @@ public class GuiDraw {
             return;
         }
         Fluid fluid = content.getFluid();
-        int fluidColor = fluid.getColor(content);
         IIcon fluidStill = fluid.getIcon(content);
         if (fluidStill == null) {
-            if (Color.getAlpha(fluidColor) == 0) {
-                fluidColor = Color.withAlpha(fluidColor, 255);
-            }
-            drawRect(x0, y0, width, height, fluidColor);
-            return;
+            fluidStill = Minecraft.getMinecraft().getTextureMapBlocks().getAtlasSprite("missingno");
         }
         if (ModularUI.Mods.HODGEPODGE.isLoaded() && fluidStill instanceof IPatchedTextureAtlasSprite) {
             ((IPatchedTextureAtlasSprite) fluidStill).markNeedsAnimationUpdate();
         }
+        int fluidColor = fluid.getColor(content);
         float r = Color.getRedF(fluidColor), g = Color.getGreenF(fluidColor), b = Color.getBlueF(fluidColor), a = Color.getAlphaF(fluidColor);
         a = a == 0f ? 1f : a;
         GlStateManager.color(r, g, b, a);

--- a/src/main/java/com/cleanroommc/modularui/drawable/GuiDraw.java
+++ b/src/main/java/com/cleanroommc/modularui/drawable/GuiDraw.java
@@ -33,7 +33,9 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 import org.lwjgl.opengl.GL11;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 
 public class GuiDraw {
@@ -322,11 +324,18 @@ public class GuiDraw {
             return;
         }
         Fluid fluid = content.getFluid();
+        int fluidColor = fluid.getColor(content);
         IIcon fluidStill = fluid.getIcon(content);
+        if (fluidStill == null) {
+            if (Color.getAlpha(fluidColor) == 0) {
+                fluidColor = Color.withAlpha(fluidColor, 255);
+            }
+            drawRect(x0, y0, width, height, fluidColor);
+            return;
+        }
         if (ModularUI.Mods.HODGEPODGE.isLoaded() && fluidStill instanceof IPatchedTextureAtlasSprite) {
             ((IPatchedTextureAtlasSprite) fluidStill).markNeedsAnimationUpdate();
         }
-        int fluidColor = fluid.getColor(content);
         float r = Color.getRedF(fluidColor), g = Color.getGreenF(fluidColor), b = Color.getBlueF(fluidColor), a = Color.getAlphaF(fluidColor);
         a = a == 0f ? 1f : a;
         GlStateManager.color(r, g, b, a);


### PR DESCRIPTION
nstead of crashing, it now does this:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/cbd0fa7a-74c5-41c5-ae32-c00221bfc511" />

This partially fixes the issue from:
https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24578

However, the game still crashes:
https://mclo.gs/QWXE6dQ

I also had these two in my mods folder to make it more readable: 
https://github.com/GTNewHorizons/Angelica/pull/1729
https://github.com/GTNewHorizons/BetterCrashes/pull/17