### PR TITLE
Disallow sync handler c2s by default

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/api/widget/ISynced.java
+++ b/src/main/java/com/cleanroommc/modularui/api/widget/ISynced.java
@@ -91,16 +91,16 @@ public interface ISynced<W extends IWidget> {
 
     @ApiStatus.ScheduledForRemoval(inVersion = "3.2.0")
     @Deprecated
-    default <T> GenericSyncValue<T> castIfTypeGenericElseNull(SyncHandler<?> syncHandler, Class<T> clazz) {
+    default <T> GenericSyncValue<T, ?> castIfTypeGenericElseNull(SyncHandler<?> syncHandler, Class<T> clazz) {
         return castIfTypeGenericElseNull(syncHandler, clazz, null);
     }
 
     @ApiStatus.ScheduledForRemoval(inVersion = "3.2.0")
     @Deprecated
-    default <T> GenericSyncValue<T> castIfTypeGenericElseNull(SyncHandler<?> syncHandler, Class<T> clazz,
-                                                              @Nullable Consumer<GenericSyncValue<T>> setup) {
-        if (syncHandler instanceof GenericSyncValue<?> genericSyncValue && genericSyncValue.isOfType(clazz)) {
-            GenericSyncValue<T> t = genericSyncValue.cast();
+    default <T> GenericSyncValue<T, ?> castIfTypeGenericElseNull(SyncHandler<?> syncHandler, Class<T> clazz,
+                                                                 @Nullable Consumer<GenericSyncValue<T, ?>> setup) {
+        if (syncHandler instanceof GenericSyncValue<?, ?> genericSyncValue && genericSyncValue.isOfType(clazz)) {
+            GenericSyncValue<T, ?> t = genericSyncValue.cast();
             if (setup != null) setup.accept(t);
             return t;
         }

--- a/src/main/java/com/cleanroommc/modularui/api/widget/ISynced.java
+++ b/src/main/java/com/cleanroommc/modularui/api/widget/ISynced.java
@@ -39,7 +39,7 @@ public interface ISynced<W extends IWidget> {
      */
     @ApiStatus.ScheduledForRemoval(inVersion = "3.2.0")
     @Deprecated
-    default boolean isValidSyncHandler(SyncHandler syncHandler) {
+    default boolean isValidSyncHandler(SyncHandler<?> syncHandler) {
         return false;
     }
 
@@ -53,7 +53,7 @@ public interface ISynced<W extends IWidget> {
      * @return if the value or sync handler is valid for this class
      */
     default boolean isValidSyncOrValue(@NotNull ISyncOrValue syncOrValue) {
-        return !(syncOrValue instanceof SyncHandler syncHandler) || isValidSyncHandler(syncHandler);
+        return !(syncOrValue instanceof SyncHandler<?> syncHandler) || isValidSyncHandler(syncHandler);
     }
 
     /**
@@ -73,14 +73,14 @@ public interface ISynced<W extends IWidget> {
 
     @ApiStatus.ScheduledForRemoval(inVersion = "3.2.0")
     @Deprecated
-    default <T> T castIfTypeElseNull(SyncHandler syncHandler, Class<T> clazz) {
+    default <T> T castIfTypeElseNull(SyncHandler<?> syncHandler, Class<T> clazz) {
         return castIfTypeElseNull(syncHandler, clazz, null);
     }
 
     @ApiStatus.ScheduledForRemoval(inVersion = "3.2.0")
     @Deprecated
     @SuppressWarnings("unchecked")
-    default <T> T castIfTypeElseNull(SyncHandler syncHandler, Class<T> clazz, @Nullable Consumer<T> setup) {
+    default <T> T castIfTypeElseNull(SyncHandler<?> syncHandler, Class<T> clazz, @Nullable Consumer<T> setup) {
         if (syncHandler != null && clazz.isAssignableFrom(syncHandler.getClass())) {
             T t = (T) syncHandler;
             if (setup != null) setup.accept(t);
@@ -91,13 +91,13 @@ public interface ISynced<W extends IWidget> {
 
     @ApiStatus.ScheduledForRemoval(inVersion = "3.2.0")
     @Deprecated
-    default <T> GenericSyncValue<T> castIfTypeGenericElseNull(SyncHandler syncHandler, Class<T> clazz) {
+    default <T> GenericSyncValue<T> castIfTypeGenericElseNull(SyncHandler<?> syncHandler, Class<T> clazz) {
         return castIfTypeGenericElseNull(syncHandler, clazz, null);
     }
 
     @ApiStatus.ScheduledForRemoval(inVersion = "3.2.0")
     @Deprecated
-    default <T> GenericSyncValue<T> castIfTypeGenericElseNull(SyncHandler syncHandler, Class<T> clazz,
+    default <T> GenericSyncValue<T> castIfTypeGenericElseNull(SyncHandler<?> syncHandler, Class<T> clazz,
                                                               @Nullable Consumer<GenericSyncValue<T>> setup) {
         if (syncHandler instanceof GenericSyncValue<?> genericSyncValue && genericSyncValue.isOfType(clazz)) {
             GenericSyncValue<T> t = genericSyncValue.cast();
@@ -117,7 +117,7 @@ public interface ISynced<W extends IWidget> {
      * @throws IllegalStateException if this widget has no valid sync handler
      */
     @NotNull
-    SyncHandler getSyncHandler();
+    SyncHandler<?> getSyncHandler();
 
     /**
      * Sets the sync handler key. The sync handler will be obtained in {@link #initialiseSyncHandler(ModularSyncManager, boolean)}

--- a/src/main/java/com/cleanroommc/modularui/network/ModularNetwork.java
+++ b/src/main/java/com/cleanroommc/modularui/network/ModularNetwork.java
@@ -119,7 +119,7 @@ public abstract class ModularNetwork {
         }
 
         @Override
-        public void sendSyncHandlerPacket(String panel, SyncHandler syncHandler, PacketBuffer buffer, EntityPlayer player) {
+        public void sendSyncHandlerPacket(String panel, SyncHandler<?> syncHandler, PacketBuffer buffer, EntityPlayer player) {
             get(player).sendSyncHandlerPacket(panel, syncHandler, buffer, player);
         }
 

--- a/src/main/java/com/cleanroommc/modularui/network/ModularNetworkSide.java
+++ b/src/main/java/com/cleanroommc/modularui/network/ModularNetworkSide.java
@@ -80,7 +80,7 @@ public abstract class ModularNetworkSide {
     }
 
     @ApiStatus.Internal
-    public void sendSyncHandlerPacket(String panel, SyncHandler syncHandler, PacketBuffer buffer, EntityPlayer player) {
+    public void sendSyncHandlerPacket(String panel, SyncHandler<?> syncHandler, PacketBuffer buffer, EntityPlayer player) {
         ModularSyncManager msm = syncHandler.getSyncManager().getModularSyncManager();
         if (!inverseActiveScreens.containsKey(msm)) return;
         int id = inverseActiveScreens.getInt(msm);

--- a/src/main/java/com/cleanroommc/modularui/value/sync/AbstractGenericSyncValue.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/AbstractGenericSyncValue.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-public abstract class AbstractGenericSyncValue<T> extends ValueSyncHandler<T> {
+public abstract class AbstractGenericSyncValue<T, S extends AbstractGenericSyncValue<T, S>> extends ValueSyncHandler<T, S> {
 
     private final Class<T> type;
     private final Supplier<T> getter;
@@ -137,8 +137,8 @@ public abstract class AbstractGenericSyncValue<T> extends ValueSyncHandler<T> {
     }
 
     @SuppressWarnings("unchecked")
-    public <V> AbstractGenericSyncValue<V> cast() {
-        return (AbstractGenericSyncValue<V>) this;
+    public <V> AbstractGenericSyncValue<V, ?> cast() {
+        return (AbstractGenericSyncValue<V, ?>) this;
     }
 
     /**

--- a/src/main/java/com/cleanroommc/modularui/value/sync/BigDecimalSyncValue.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/BigDecimalSyncValue.java
@@ -11,7 +11,7 @@ import java.math.BigDecimal;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-public class BigDecimalSyncValue extends GenericSyncValue<BigDecimal> implements IStringValue<BigDecimal> {
+public class BigDecimalSyncValue extends GenericSyncValue<BigDecimal, BigDecimalSyncValue> implements IStringValue<BigDecimal> {
 
     public BigDecimalSyncValue(@NotNull Supplier<BigDecimal> getter, @Nullable Consumer<BigDecimal> setter) {
         this(getter, setter, false);

--- a/src/main/java/com/cleanroommc/modularui/value/sync/BigIntSyncValue.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/BigIntSyncValue.java
@@ -11,7 +11,7 @@ import java.math.BigInteger;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-public class BigIntSyncValue extends GenericSyncValue<BigInteger> implements IStringValue<BigInteger> {
+public class BigIntSyncValue extends GenericSyncValue<BigInteger, BigIntSyncValue> implements IStringValue<BigInteger> {
 
     public BigIntSyncValue(@NotNull Supplier<BigInteger> getter, @Nullable Consumer<BigInteger> setter) {
         this(getter, setter, false);

--- a/src/main/java/com/cleanroommc/modularui/value/sync/BinaryEnumSyncValue.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/BinaryEnumSyncValue.java
@@ -12,7 +12,7 @@ import java.util.function.Supplier;
 /**
  * Accepts enums which have exactly two elements. Can act as {@link IBoolSyncValue}.
  */
-public class BinaryEnumSyncValue<T extends Enum<T>> extends EnumSyncValue<T> implements IBoolSyncValue<T> {
+public class BinaryEnumSyncValue<T extends Enum<T>, S extends BinaryEnumSyncValue<T, S>> extends EnumSyncValue<T, S> implements IBoolSyncValue<T> {
 
     public BinaryEnumSyncValue(@NotNull Class<T> enumClass, @NotNull Supplier<T> getter, @Nullable Consumer<T> setter) {
         super(enumClass, getter, setter);

--- a/src/main/java/com/cleanroommc/modularui/value/sync/BinaryEnumSyncValue.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/BinaryEnumSyncValue.java
@@ -6,13 +6,14 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.math.BigInteger;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 /**
  * Accepts enums which have exactly two elements. Can act as {@link IBoolSyncValue}.
  */
-public class BinaryEnumSyncValue<T extends Enum<T>, S extends BinaryEnumSyncValue<T, S>> extends EnumSyncValue<T, BinaryEnumSyncValue<T, S>> implements IBoolSyncValue<T> {
+public class BinaryEnumSyncValue<T extends Enum<T>, S extends BinaryEnumSyncValue<T, S>> extends EnumSyncValue<T, S> implements IBoolSyncValue<T> {
 
     public BinaryEnumSyncValue(@NotNull Class<T> enumClass, @NotNull Supplier<T> getter, @Nullable Consumer<T> setter) {
         super(enumClass, getter, setter);

--- a/src/main/java/com/cleanroommc/modularui/value/sync/BinaryEnumSyncValue.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/BinaryEnumSyncValue.java
@@ -12,7 +12,7 @@ import java.util.function.Supplier;
 /**
  * Accepts enums which have exactly two elements. Can act as {@link IBoolSyncValue}.
  */
-public class BinaryEnumSyncValue<T extends Enum<T>, S extends BinaryEnumSyncValue<T, S>> extends EnumSyncValue<T, S> implements IBoolSyncValue<T> {
+public class BinaryEnumSyncValue<T extends Enum<T>, S extends BinaryEnumSyncValue<T, S>> extends EnumSyncValue<T, BinaryEnumSyncValue<T, S>> implements IBoolSyncValue<T> {
 
     public BinaryEnumSyncValue(@NotNull Class<T> enumClass, @NotNull Supplier<T> getter, @Nullable Consumer<T> setter) {
         super(enumClass, getter, setter);

--- a/src/main/java/com/cleanroommc/modularui/value/sync/BooleanSyncValue.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/BooleanSyncValue.java
@@ -14,7 +14,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Objects;
 import java.util.function.BooleanSupplier;
 
-public class BooleanSyncValue extends ValueSyncHandler<Boolean> implements IBoolSyncValue<Boolean>, IStringSyncValue<Boolean> {
+public class BooleanSyncValue extends ValueSyncHandler<Boolean, BooleanSyncValue> implements IBoolSyncValue<Boolean>, IStringSyncValue<Boolean> {
 
     private final BooleanSupplier getter;
     private final BooleanConsumer setter;

--- a/src/main/java/com/cleanroommc/modularui/value/sync/ByteArraySyncValue.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/ByteArraySyncValue.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-public class ByteArraySyncValue extends GenericSyncValue<byte[]> {
+public class ByteArraySyncValue extends GenericSyncValue<byte[], ByteArraySyncValue> {
 
     public ByteArraySyncValue(@NotNull Supplier<byte[]> getter, @Nullable Consumer<byte[]> setter) {
         this(getter, setter, false);

--- a/src/main/java/com/cleanroommc/modularui/value/sync/ByteSyncValue.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/ByteSyncValue.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 
-public class ByteSyncValue extends ValueSyncHandler<Byte> implements IByteSyncValue<Byte> {
+public class ByteSyncValue extends ValueSyncHandler<Byte, ByteSyncValue> implements IByteSyncValue<Byte> {
 
     private byte cache;
     private final ByteValue.Supplier getter;

--- a/src/main/java/com/cleanroommc/modularui/value/sync/CursorSlotSyncHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/CursorSlotSyncHandler.java
@@ -6,7 +6,7 @@ import net.minecraft.network.PacketBuffer;
 
 import java.io.IOException;
 
-public class CursorSlotSyncHandler extends SyncHandler {
+public class CursorSlotSyncHandler extends SyncHandler<CursorSlotSyncHandler> {
 
     public void sync() {
         sync(0, buffer -> NetworkUtils.writeItemStack(buffer, getSyncManager().getPlayer().inventory.getItemStack()));

--- a/src/main/java/com/cleanroommc/modularui/value/sync/DoubleSyncValue.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/DoubleSyncValue.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 import java.util.function.DoubleConsumer;
 import java.util.function.DoubleSupplier;
 
-public class DoubleSyncValue extends ValueSyncHandler<Double> implements IDoubleSyncValue<Double>, IFloatSyncValue<Double>, IStringSyncValue<Double> {
+public class DoubleSyncValue extends ValueSyncHandler<Double, DoubleSyncValue> implements IDoubleSyncValue<Double>, IFloatSyncValue<Double>, IStringSyncValue<Double> {
 
     private final DoubleSupplier getter;
     private final DoubleConsumer setter;

--- a/src/main/java/com/cleanroommc/modularui/value/sync/DynamicLinkedSyncHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/DynamicLinkedSyncHandler.java
@@ -19,7 +19,7 @@ import java.util.function.Supplier;
  * To use it simply pass in a registered value sync handler into the constructor and link it to a
  * {@link com.cleanroommc.modularui.widgets.DynamicSyncedWidget DynamicSyncedWidget}.
  */
-public class DynamicLinkedSyncHandler<S extends ValueSyncHandler<?>> extends SyncHandler implements IDynamicSyncNotifiable {
+public class DynamicLinkedSyncHandler<S extends ValueSyncHandler<?, ?>> extends SyncHandler<DynamicLinkedSyncHandler<S>> implements IDynamicSyncNotifiable {
 
     private IWidgetProvider<S> widgetProvider;
     private Consumer<IWidget> onWidgetUpdate;
@@ -120,7 +120,7 @@ public class DynamicLinkedSyncHandler<S extends ValueSyncHandler<?>> extends Syn
         }
     }
 
-    public interface IWidgetProvider<S extends ValueSyncHandler<?>> {
+    public interface IWidgetProvider<S extends ValueSyncHandler<?, ?>> {
 
         /**
          * This is the function which creates a widget on client and server.

--- a/src/main/java/com/cleanroommc/modularui/value/sync/DynamicSyncHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/DynamicSyncHandler.java
@@ -22,7 +22,7 @@ import java.util.function.Supplier;
  * {@link ISyncRegistrar#getOrCreateSyncHandler(String, int, Class, Supplier)}.
  */
 @ApiStatus.Obsolete
-public class DynamicSyncHandler extends SyncHandler implements IDynamicSyncNotifiable {
+public class DynamicSyncHandler extends SyncHandler<DynamicSyncHandler> implements IDynamicSyncNotifiable {
 
     private IWidgetProvider widgetProvider;
     private Consumer<IWidget> onWidgetUpdate;

--- a/src/main/java/com/cleanroommc/modularui/value/sync/EnumSyncValue.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/EnumSyncValue.java
@@ -14,7 +14,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-public class EnumSyncValue<T extends Enum<T>, S extends EnumSyncValue<T, S>> extends ValueSyncHandler<T, EnumSyncValue<T, S>> implements IEnumValue<T>, IIntSyncValue<T> {
+public class EnumSyncValue<T extends Enum<T>, S extends EnumSyncValue<T, S>> extends ValueSyncHandler<T, S> implements IEnumValue<T>, IIntSyncValue<T> {
 
     protected final Class<T> enumClass;
     private final Supplier<T> getter;

--- a/src/main/java/com/cleanroommc/modularui/value/sync/EnumSyncValue.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/EnumSyncValue.java
@@ -14,7 +14,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-public class EnumSyncValue<T extends Enum<T>> extends ValueSyncHandler<T, EnumSyncValue<T>> implements IEnumValue<T>, IIntSyncValue<T> {
+public class EnumSyncValue<T extends Enum<T>, S extends EnumSyncValue<T, S>> extends ValueSyncHandler<T, EnumSyncValue<T, S>> implements IEnumValue<T>, IIntSyncValue<T> {
 
     protected final Class<T> enumClass;
     private final Supplier<T> getter;

--- a/src/main/java/com/cleanroommc/modularui/value/sync/EnumSyncValue.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/EnumSyncValue.java
@@ -14,7 +14,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-public class EnumSyncValue<T extends Enum<T>> extends ValueSyncHandler<T> implements IEnumValue<T>, IIntSyncValue<T> {
+public class EnumSyncValue<T extends Enum<T>> extends ValueSyncHandler<T, EnumSyncValue<T>> implements IEnumValue<T>, IIntSyncValue<T> {
 
     protected final Class<T> enumClass;
     private final Supplier<T> getter;

--- a/src/main/java/com/cleanroommc/modularui/value/sync/FloatSyncValue.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/FloatSyncValue.java
@@ -15,7 +15,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 
-public class FloatSyncValue extends ValueSyncHandler<Float> implements IFloatSyncValue<Float>, IDoubleSyncValue<Float>, IStringSyncValue<Float> {
+public class FloatSyncValue extends ValueSyncHandler<Float, FloatSyncValue> implements IFloatSyncValue<Float>, IDoubleSyncValue<Float>, IStringSyncValue<Float> {
 
     private final FloatSupplier getter;
     private final FloatConsumer setter;

--- a/src/main/java/com/cleanroommc/modularui/value/sync/FluidSlotSyncHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/FluidSlotSyncHandler.java
@@ -16,7 +16,7 @@ import net.minecraftforge.fluids.IFluidTank;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class FluidSlotSyncHandler extends ValueSyncHandler<FluidStack> {
+public class FluidSlotSyncHandler extends ValueSyncHandler<FluidStack, FluidSlotSyncHandler> {
 
     public static boolean isFluidEmpty(@Nullable FluidStack fluidStack) {
         return fluidStack == null;
@@ -40,6 +40,7 @@ public class FluidSlotSyncHandler extends ValueSyncHandler<FluidStack> {
 
     public FluidSlotSyncHandler(IFluidTank fluidTank) {
         this.fluidTank = fluidTank;
+        allowC2S();
     }
 
     public FluidSlotSyncHandler(IMultiFluidTankHandler fluidHandler, int index) {

--- a/src/main/java/com/cleanroommc/modularui/value/sync/GenericCollectionSyncHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/GenericCollectionSyncHandler.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-public abstract class GenericCollectionSyncHandler<T, C extends Collection<T>> extends ValueSyncHandler<C> {
+public abstract class GenericCollectionSyncHandler<T, C extends Collection<T>, S extends GenericCollectionSyncHandler<T, C, S>> extends ValueSyncHandler<C, S> {
 
     private final Supplier<C> getter;
     private final Consumer<C> setter;

--- a/src/main/java/com/cleanroommc/modularui/value/sync/GenericListSyncHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/GenericListSyncHandler.java
@@ -19,7 +19,7 @@ import java.util.function.Consumer;
 import java.util.function.IntFunction;
 import java.util.function.Supplier;
 
-public class GenericListSyncHandler<T> extends GenericCollectionSyncHandler<T, List<T>> {
+public class GenericListSyncHandler<T> extends GenericCollectionSyncHandler<T, List<T>, GenericListSyncHandler<T>> {
 
     private final ObjectList<T> cache = ObjectList.create();
 

--- a/src/main/java/com/cleanroommc/modularui/value/sync/GenericMapSyncHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/GenericMapSyncHandler.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-public class GenericMapSyncHandler<K, V> extends ValueSyncHandler<Map<K, V>> {
+public class GenericMapSyncHandler<K, V> extends ValueSyncHandler<Map<K, V>, GenericMapSyncHandler<K, V>> {
 
     private final Supplier<Map<K, V>> getter;
     private final Consumer<Map<K, V>> setter;

--- a/src/main/java/com/cleanroommc/modularui/value/sync/GenericSetSyncHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/GenericSetSyncHandler.java
@@ -16,7 +16,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-public class GenericSetSyncHandler<T> extends GenericCollectionSyncHandler<T, Set<T>> {
+public class GenericSetSyncHandler<T> extends GenericCollectionSyncHandler<T, Set<T>, GenericSetSyncHandler<T>> {
 
     private final Set<T> cache = new ObjectOpenHashSet<>();
 

--- a/src/main/java/com/cleanroommc/modularui/value/sync/GenericSyncValue.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/GenericSyncValue.java
@@ -45,7 +45,7 @@ import java.util.function.Supplier;
  *
  * @param <T> type of the value to sync
  */
-public class GenericSyncValue<T, S extends GenericSyncValue<T, S>> extends AbstractGenericSyncValue<T, GenericSyncValue<T, S>> {
+public class GenericSyncValue<T, S extends GenericSyncValue<T, S>> extends AbstractGenericSyncValue<T, S> {
 
     public static GenericSyncValue<ItemStack, ?> forItem(@NotNull Supplier<ItemStack> getter, @Nullable Consumer<ItemStack> setter) {
         return new GenericSyncValue<>(getter, setter, ByteBufAdapters.ITEM_STACK);

--- a/src/main/java/com/cleanroommc/modularui/value/sync/GenericSyncValue.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/GenericSyncValue.java
@@ -45,7 +45,7 @@ import java.util.function.Supplier;
  *
  * @param <T> type of the value to sync
  */
-public class GenericSyncValue<T> extends AbstractGenericSyncValue<T> {
+public class GenericSyncValue<T> extends AbstractGenericSyncValue<T, GenericSyncValue<T>> {
 
     public static GenericSyncValue<ItemStack> forItem(@NotNull Supplier<ItemStack> getter, @Nullable Consumer<ItemStack> setter) {
         return new GenericSyncValue<>(getter, setter, ByteBufAdapters.ITEM_STACK);

--- a/src/main/java/com/cleanroommc/modularui/value/sync/GenericSyncValue.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/GenericSyncValue.java
@@ -45,13 +45,13 @@ import java.util.function.Supplier;
  *
  * @param <T> type of the value to sync
  */
-public class GenericSyncValue<T> extends AbstractGenericSyncValue<T, GenericSyncValue<T>> {
+public class GenericSyncValue<T, S extends GenericSyncValue<T, S>> extends AbstractGenericSyncValue<T, GenericSyncValue<T, S>> {
 
-    public static GenericSyncValue<ItemStack> forItem(@NotNull Supplier<ItemStack> getter, @Nullable Consumer<ItemStack> setter) {
+    public static GenericSyncValue<ItemStack, ?> forItem(@NotNull Supplier<ItemStack> getter, @Nullable Consumer<ItemStack> setter) {
         return new GenericSyncValue<>(getter, setter, ByteBufAdapters.ITEM_STACK);
     }
 
-    public static GenericSyncValue<FluidStack> forFluid(@NotNull Supplier<FluidStack> getter, @Nullable Consumer<FluidStack> setter) {
+    public static GenericSyncValue<FluidStack, ?> forFluid(@NotNull Supplier<FluidStack> getter, @Nullable Consumer<FluidStack> setter) {
         return new GenericSyncValue<>(getter, setter, ByteBufAdapters.FLUID_STACK);
     }
 
@@ -264,8 +264,8 @@ public class GenericSyncValue<T> extends AbstractGenericSyncValue<T, GenericSync
 
     @Override
     @SuppressWarnings("unchecked")
-    public <V> GenericSyncValue<V> cast() {
-        return (GenericSyncValue<V>) this;
+    public <V> GenericSyncValue<V, ?> cast() {
+        return (GenericSyncValue<V, ?>) this;
     }
 
     /**
@@ -472,7 +472,7 @@ public class GenericSyncValue<T> extends AbstractGenericSyncValue<T, GenericSync
          * @throws NullPointerException     if the getter, serializer or deserializer is null
          * @throws IllegalArgumentException if the value type is null and the getter returns null
          */
-        public GenericSyncValue<T> build() {
+        public GenericSyncValue<T, ?> build() {
             return new GenericSyncValue<>(type, getter, setter, deserializer, serializer, equals, copy, nullable);
         }
     }

--- a/src/main/java/com/cleanroommc/modularui/value/sync/ISyncRegistrar.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/ISyncRegistrar.java
@@ -18,15 +18,15 @@ import java.util.function.Supplier;
 
 public interface ISyncRegistrar<S extends ISyncRegistrar<S>> {
 
-    boolean hasSyncHandler(SyncHandler syncHandler);
+    boolean hasSyncHandler(SyncHandler<?> syncHandler);
 
-    default S syncValue(String name, SyncHandler syncHandler) {
+    default S syncValue(String name, SyncHandler<?> syncHandler) {
         return syncValue(name, 0, syncHandler);
     }
 
-    S syncValue(String name, int id, SyncHandler syncHandler);
+    S syncValue(String name, int id, SyncHandler<?> syncHandler);
 
-    default S syncValue(int id, SyncHandler syncHandler) {
+    default S syncValue(int id, SyncHandler<?> syncHandler) {
         return syncValue("_", id, syncHandler);
     }
 
@@ -113,17 +113,17 @@ public interface ISyncRegistrar<S extends ISyncRegistrar<S>> {
 
     S registerSyncedAction(String mapKey, boolean executeClient, boolean executeServer, ISyncedAction action);
 
-    default <T extends SyncHandler> T getOrCreateSyncHandler(String name, Class<T> clazz, Supplier<T> supplier) {
+    default <T extends SyncHandler<?>> T getOrCreateSyncHandler(String name, Class<T> clazz, Supplier<T> supplier) {
         return getOrCreateSyncHandler(name, 0, clazz, supplier);
     }
 
-    <T extends SyncHandler> T getOrCreateSyncHandler(String name, int id, Class<T> clazz, Supplier<T> supplier);
+    <T extends SyncHandler<?>> T getOrCreateSyncHandler(String name, int id, Class<T> clazz, Supplier<T> supplier);
 
-    default <T extends SyncHandler> T getOrCreateSH(String name, Class<T> clazz, Supplier<T> supplier) {
+    default <T extends SyncHandler<?>> T getOrCreateSH(String name, Class<T> clazz, Supplier<T> supplier) {
         return getOrCreateSyncHandler(name, 0, clazz, supplier);
     }
 
-    default <T extends SyncHandler> T getOrCreateSH(String name, int id, Class<T> clazz, Supplier<T> supplier) {
+    default <T extends SyncHandler<?>> T getOrCreateSH(String name, int id, Class<T> clazz, Supplier<T> supplier) {
         return getOrCreateSyncHandler(name, id, clazz, supplier);
     }
 
@@ -135,38 +135,38 @@ public interface ISyncRegistrar<S extends ISyncRegistrar<S>> {
         return getOrCreateSyncHandler(name, id, ItemSlotSH.class, () -> new ItemSlotSH(slotSupplier.get()));
     }
 
-    @Nullable SyncHandler findSyncHandlerNullable(String name, int id);
+    @Nullable SyncHandler<?> findSyncHandlerNullable(String name, int id);
 
-    default @Nullable SyncHandler findSyncHandlerNullable(String name) {
+    default @Nullable SyncHandler<?> findSyncHandlerNullable(String name) {
         return findSyncHandlerNullable(name, 0);
     }
 
-    default @NotNull SyncHandler findSyncHandler(String name, int id) {
-        SyncHandler syncHandler = findSyncHandlerNullable(name, id);
+    default @NotNull SyncHandler<?> findSyncHandler(String name, int id) {
+        SyncHandler<?> syncHandler = findSyncHandlerNullable(name, id);
         if (syncHandler == null) {
             throw new NoSuchElementException("Expected to find sync handler with key '" + makeSyncKey(name, id) + "', but none was found.");
         }
         return syncHandler;
     }
 
-    default @NotNull SyncHandler findSyncHandler(String name) {
+    default @NotNull SyncHandler<?> findSyncHandler(String name) {
         return findSyncHandler(name, 0);
     }
 
-    default <T extends SyncHandler> @Nullable T findSyncHandlerNullable(String name, int id, Class<T> type) {
-        SyncHandler syncHandler = findSyncHandlerNullable(name, id);
+    default <T extends SyncHandler<?>> @Nullable T findSyncHandlerNullable(String name, int id, Class<T> type) {
+        SyncHandler<?> syncHandler = findSyncHandlerNullable(name, id);
         if (syncHandler != null && type.isAssignableFrom(syncHandler.getClass())) {
             return type.cast(syncHandler);
         }
         return null;
     }
 
-    default <T extends SyncHandler> @Nullable T findSyncHandlerNullable(String name, Class<T> type) {
+    default <T extends SyncHandler<?>> @Nullable T findSyncHandlerNullable(String name, Class<T> type) {
         return findSyncHandlerNullable(name, 0, type);
     }
 
-    default <T extends SyncHandler> @NotNull T findSyncHandler(String name, int id, Class<T> type) {
-        SyncHandler syncHandler = findSyncHandlerNullable(name, id);
+    default <T extends SyncHandler<?>> @NotNull T findSyncHandler(String name, int id, Class<T> type) {
+        SyncHandler<?> syncHandler = findSyncHandlerNullable(name, id);
         if (syncHandler == null) {
             throw new NoSuchElementException("Expected to find sync handler with key '" + makeSyncKey(name, id) + "', but none was found.");
         }
@@ -177,7 +177,7 @@ public interface ISyncRegistrar<S extends ISyncRegistrar<S>> {
         return type.cast(syncHandler);
     }
 
-    default <T extends SyncHandler> @NotNull T findSyncHandler(String name, Class<T> type) {
+    default <T extends SyncHandler<?>> @NotNull T findSyncHandler(String name, Class<T> type) {
         return findSyncHandler(name, 0, type);
     }
 

--- a/src/main/java/com/cleanroommc/modularui/value/sync/IntSyncValue.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/IntSyncValue.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 import java.util.function.IntConsumer;
 import java.util.function.IntSupplier;
 
-public class IntSyncValue extends ValueSyncHandler<Integer> implements IIntSyncValue<Integer>, IDoubleSyncValue<Integer>, IStringSyncValue<Integer> {
+public class IntSyncValue extends ValueSyncHandler<Integer, IntSyncValue> implements IIntSyncValue<Integer>, IDoubleSyncValue<Integer>, IStringSyncValue<Integer> {
 
     private int cache;
     private final IntSupplier getter;

--- a/src/main/java/com/cleanroommc/modularui/value/sync/InteractionSyncHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/InteractionSyncHandler.java
@@ -19,6 +19,10 @@ public class InteractionSyncHandler extends SyncHandler<InteractionSyncHandler> 
     private IServerKeyboardAction keyReleased;
     private IServerKeyboardAction keyTapped;
 
+    public InteractionSyncHandler(){
+        allowC2S();
+    }
+
     @Override
     public void readOnClient(int id, PacketBuffer buf) throws IOException {
     }

--- a/src/main/java/com/cleanroommc/modularui/value/sync/InteractionSyncHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/InteractionSyncHandler.java
@@ -9,7 +9,7 @@ import net.minecraft.network.PacketBuffer;
 
 import java.io.IOException;
 
-public class InteractionSyncHandler extends SyncHandler {
+public class InteractionSyncHandler extends SyncHandler<InteractionSyncHandler> {
 
     private IServerMouseAction mousePressed;
     private IServerMouseAction mouseReleased;

--- a/src/main/java/com/cleanroommc/modularui/value/sync/ItemSlotSH.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/ItemSlotSH.java
@@ -16,7 +16,7 @@ import java.io.IOException;
  * Wraps a slot and handles interactions for phantom slots.
  * Use {@link ModularSlot} directly.
  */
-public class ItemSlotSH extends SyncHandler {
+public class ItemSlotSH extends SyncHandler<ItemSlotSH> {
 
     public static final int SYNC_ITEM = 0;
     public static final int SYNC_ENABLED = 1;
@@ -29,6 +29,7 @@ public class ItemSlotSH extends SyncHandler {
     public ItemSlotSH(ModularSlot slot) {
         this.slot = slot;
         this.playerSlotType = PlayerSlotType.getPlayerSlotType(slot);
+        allowC2S();
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/modularui/value/sync/LongArraySyncValue.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/LongArraySyncValue.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-public class LongArraySyncValue extends GenericSyncValue<long[]> {
+public class LongArraySyncValue extends GenericSyncValue<long[], LongArraySyncValue> {
 
     public LongArraySyncValue(@NotNull Supplier<long[]> getter, @Nullable Consumer<long[]> setter) {
         this(getter, setter, false);

--- a/src/main/java/com/cleanroommc/modularui/value/sync/LongSyncValue.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/LongSyncValue.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 import java.util.function.LongConsumer;
 import java.util.function.LongSupplier;
 
-public class LongSyncValue extends ValueSyncHandler<Long> implements ILongSyncValue<Long>, IIntSyncValue<Long>, IStringSyncValue<Long> {
+public class LongSyncValue extends ValueSyncHandler<Long, LongSyncValue> implements ILongSyncValue<Long>, IIntSyncValue<Long>, IStringSyncValue<Long> {
 
     private final LongSupplier getter;
     private final LongConsumer setter;

--- a/src/main/java/com/cleanroommc/modularui/value/sync/ModularSyncManager.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/ModularSyncManager.java
@@ -113,7 +113,7 @@ public class ModularSyncManager implements ISyncRegistrar<ModularSyncManager> {
         throw new NullPointerException("No PanelSyncManager found for name '" + panelName + "'!");
     }
 
-    public @Nullable SyncHandler getSyncHandler(String panelName, String syncKey) {
+    public @Nullable SyncHandler<?> getSyncHandler(String panelName, String syncKey) {
         return getPanelSyncManager(panelName).getSyncHandlerFromMapKey(syncKey);
     }
 
@@ -182,12 +182,12 @@ public class ModularSyncManager implements ISyncRegistrar<ModularSyncManager> {
     }
 
     @Override
-    public boolean hasSyncHandler(SyncHandler syncHandler) {
+    public boolean hasSyncHandler(SyncHandler<?> syncHandler) {
         return this.mainPSM.hasSyncHandler(syncHandler);
     }
 
     @Override
-    public ModularSyncManager syncValue(String name, int id, SyncHandler syncHandler) {
+    public ModularSyncManager syncValue(String name, int id, SyncHandler<?> syncHandler) {
         this.mainPSM.syncValue(name, id, syncHandler);
         return this;
     }
@@ -215,12 +215,12 @@ public class ModularSyncManager implements ISyncRegistrar<ModularSyncManager> {
     }
 
     @Override
-    public <T extends SyncHandler> T getOrCreateSyncHandler(String name, int id, Class<T> clazz, Supplier<T> supplier) {
+    public <T extends SyncHandler<?>> T getOrCreateSyncHandler(String name, int id, Class<T> clazz, Supplier<T> supplier) {
         return this.mainPSM.getOrCreateSyncHandler(name, id, clazz, supplier);
     }
 
     @Override
-    public @Nullable SyncHandler findSyncHandlerNullable(String name, int id) {
+    public @Nullable SyncHandler<?> findSyncHandlerNullable(String name, int id) {
         return this.mainPSM.findSyncHandlerNullable(name, id);
     }
 

--- a/src/main/java/com/cleanroommc/modularui/value/sync/PanelSyncHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/PanelSyncHandler.java
@@ -19,7 +19,7 @@ import java.util.Objects;
  * Register it in any {@link PanelSyncManager} (preferably the main one).
  * Then you can call {@link #openPanel()} and {@link #closePanel()} from any side.
  */
-public final class PanelSyncHandler extends SyncHandler implements IPanelHandler {
+public final class PanelSyncHandler extends SyncHandler<PanelSyncHandler> implements IPanelHandler {
 
     public static final int SYNC_NOTIFY_OPEN = 0;
     public static final int SYNC_OPEN = 1;
@@ -41,6 +41,7 @@ public final class PanelSyncHandler extends SyncHandler implements IPanelHandler
     PanelSyncHandler(IPanelBuilder panelBuilder, boolean subPanel) {
         this.panelBuilder = panelBuilder;
         this.subPanel = subPanel;
+        allowC2S();
     }
 
     public ModularPanel createUI(PanelSyncManager syncManager) {

--- a/src/main/java/com/cleanroommc/modularui/value/sync/PanelSyncManager.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/PanelSyncManager.java
@@ -18,6 +18,7 @@ import it.unimi.dsi.fastutil.objects.Object2ReferenceArrayMap;
 import it.unimi.dsi.fastutil.objects.Object2ReferenceLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2ReferenceOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
+import org.apache.logging.log4j.Level;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -33,9 +34,9 @@ import java.util.function.Supplier;
 
 public class PanelSyncManager implements ISyncRegistrar<PanelSyncManager> {
 
-    private final Map<String, SyncHandler> syncHandlers = new Object2ReferenceLinkedOpenHashMap<>();
+    private final Map<String, SyncHandler<?>> syncHandlers = new Object2ReferenceLinkedOpenHashMap<>();
     private final Map<String, SlotGroup> slotGroups = new Object2ReferenceOpenHashMap<>();
-    private final Map<SyncHandler, String> reverseSyncHandlers = new Reference2ObjectOpenHashMap<>();
+    private final Map<SyncHandler<?>, String> reverseSyncHandlers = new Reference2ObjectOpenHashMap<>();
     private final Map<String, SyncedAction> syncedActions = new Object2ReferenceOpenHashMap<>();
     private final Map<String, PanelSyncHandler> subPanels = new Object2ReferenceArrayMap<>();
     private final ModularSyncManager modularSyncManager;
@@ -65,9 +66,9 @@ public class PanelSyncManager implements ISyncRegistrar<PanelSyncManager> {
         this.subPanels.forEach((s, syncHandler) -> this.modularSyncManager.getMainPSM().registerPanelSyncHandler(s, syncHandler));
     }
 
-    private void registerPanelSyncHandler(String name, SyncHandler syncHandler) {
+    private void registerPanelSyncHandler(String name, SyncHandler<?> syncHandler) {
         // only called on main psm
-        SyncHandler currentSh = this.syncHandlers.get(name);
+        SyncHandler<?> currentSh = this.syncHandlers.get(name);
         if (currentSh != null && currentSh != syncHandler) {
             throw new IllegalStateException("Failed to register panel sync handler during initialization. " +
                     "There already exists a sync handler for the name '" + name + "'.");
@@ -109,7 +110,7 @@ public class PanelSyncManager implements ISyncRegistrar<PanelSyncManager> {
 
     void detectAndSendChanges(boolean init) {
         if (!isClient()) {
-            for (SyncHandler syncHandler : this.syncHandlers.values()) {
+            for (SyncHandler<?> syncHandler : this.syncHandlers.values()) {
                 syncHandler.detectAndSendChanges(init || this.init);
             }
         }
@@ -130,11 +131,13 @@ public class PanelSyncManager implements ISyncRegistrar<PanelSyncManager> {
             ModularUI.LOGGER.warn("SyncHandler '{}' does not exist for panel '{}'! ID was {}.", mapKey, panelName, id);
             return;
         }
-        SyncHandler syncHandler = this.syncHandlers.get(mapKey);
+        SyncHandler<?> syncHandler = this.syncHandlers.get(mapKey);
         if (isClient()) {
             syncHandler.readOnClient(id, buf);
-        } else {
+        } else if (syncHandler.isAllowC2S()) {
             syncHandler.readOnServer(id, buf);
+        } else {
+            ModularUI.LOGGER.throwing(Level.WARN, new SecurityException("Tried to send a packet to server, but the sync handler does not accept client packets."));
         }
     }
 
@@ -165,12 +168,12 @@ public class PanelSyncManager implements ISyncRegistrar<PanelSyncManager> {
     }
 
     @Override
-    public boolean hasSyncHandler(SyncHandler syncHandler) {
+    public boolean hasSyncHandler(SyncHandler<?> syncHandler) {
         if (this.reverseSyncHandlers.containsKey(syncHandler)) return true;
         return this != getHyperVisor() && getHyperVisor().hasSyncHandler(syncHandler);
     }
 
-    private void putSyncValue(String name, int id, SyncHandler syncHandler) {
+    private void putSyncValue(String name, int id, SyncHandler<?> syncHandler) {
         if (isLocked()) {
             // registration of sync handlers forbidden
             if (this.allowSyncHandlerRegistration) {
@@ -202,7 +205,7 @@ public class PanelSyncManager implements ISyncRegistrar<PanelSyncManager> {
     }
 
     @Override
-    public PanelSyncManager syncValue(String name, int id, SyncHandler syncHandler) {
+    public PanelSyncManager syncValue(String name, int id, SyncHandler<?> syncHandler) {
         Objects.requireNonNull(name, "Name must not be null");
         Objects.requireNonNull(syncHandler, "Sync Handler must not be null");
         putSyncValue(name, id, syncHandler);
@@ -215,7 +218,7 @@ public class PanelSyncManager implements ISyncRegistrar<PanelSyncManager> {
     @ApiStatus.ScheduledForRemoval(inVersion = "3.3.0")
     @Deprecated
     public IPanelHandler panel(String key, PanelSyncHandler.IPanelBuilder panelBuilder, boolean subPanel) {
-        SyncHandler sh = this.subPanels.get(key);
+        SyncHandler<?> sh = this.subPanels.get(key);
         if (sh != null) return (IPanelHandler) sh;
         PanelSyncHandler syncHandler = new PanelSyncHandler(panelBuilder, subPanel);
         this.subPanels.put(key, syncHandler);
@@ -338,8 +341,8 @@ public class PanelSyncManager implements ISyncRegistrar<PanelSyncManager> {
     }
 
     @Override
-    public <T extends SyncHandler> T getOrCreateSyncHandler(String name, int id, Class<T> clazz, Supplier<T> supplier) {
-        SyncHandler syncHandler = findSyncHandlerNullable(name, id);
+    public <T extends SyncHandler<?>> T getOrCreateSyncHandler(String name, int id, Class<T> clazz, Supplier<T> supplier) {
+        SyncHandler<?> syncHandler = findSyncHandlerNullable(name, id);
         if (syncHandler == null) {
             if (isLocked() && !this.allowSyncHandlerRegistration) {
                 // registration is locked, and we don't have permission to temporarily bypass lock
@@ -369,16 +372,16 @@ public class PanelSyncManager implements ISyncRegistrar<PanelSyncManager> {
 
     @ApiStatus.ScheduledForRemoval(inVersion = "3.2.0")
     @Deprecated
-    public @Nullable SyncHandler getSyncHandler(String mapKey) {
+    public @Nullable SyncHandler<?> getSyncHandler(String mapKey) {
         return getSyncHandlerFromMapKey(mapKey);
     }
 
-    public @Nullable SyncHandler getSyncHandlerFromMapKey(String mapKey) {
+    public @Nullable SyncHandler<?> getSyncHandlerFromMapKey(String mapKey) {
         return this.syncHandlers.get(mapKey);
     }
 
     @Override
-    public @Nullable SyncHandler findSyncHandlerNullable(String name, int id) {
+    public @Nullable SyncHandler<?> findSyncHandlerNullable(String name, int id) {
         return this.syncHandlers.get(makeSyncKey(name, id));
     }
 

--- a/src/main/java/com/cleanroommc/modularui/value/sync/ShortSyncValue.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/ShortSyncValue.java
@@ -14,7 +14,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 
-public class ShortSyncValue extends ValueSyncHandler<Short> implements IShortSyncValue<Short>, IIntSyncValue<Short>, IStringSyncValue<Short> {
+public class ShortSyncValue extends ValueSyncHandler<Short, ShortSyncValue> implements IShortSyncValue<Short>, IIntSyncValue<Short>, IStringSyncValue<Short> {
 
     private short cache;
     private final ShortValue.Supplier getter;

--- a/src/main/java/com/cleanroommc/modularui/value/sync/StringSyncValue.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/StringSyncValue.java
@@ -14,7 +14,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-public class StringSyncValue extends AbstractGenericSyncValue<String> implements IStringSyncValue<String> {
+public class StringSyncValue extends AbstractGenericSyncValue<String, StringSyncValue> implements IStringSyncValue<String> {
 
     public StringSyncValue(Supplier<String> getter, Consumer<String> setter) {
         super(String.class, getter, setter);

--- a/src/main/java/com/cleanroommc/modularui/value/sync/SyncHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/SyncHandler.java
@@ -1,5 +1,6 @@
 package com.cleanroommc.modularui.value.sync;
 
+import com.cleanroommc.modularui.ModularUI;
 import com.cleanroommc.modularui.api.IPacketWriter;
 import com.cleanroommc.modularui.api.value.ISyncOrValue;
 import com.cleanroommc.modularui.network.ModularNetwork;
@@ -10,6 +11,7 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 import io.netty.buffer.Unpooled;
+import org.apache.logging.log4j.Level;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.MustBeInvokedByOverriders;
 import org.jetbrains.annotations.NotNull;
@@ -22,10 +24,11 @@ import java.util.Objects;
  * A sync handler must exist on client and server.
  * It must be configured exactly the same to avoid issues.
  */
-public abstract class SyncHandler implements ISyncOrValue {
+public abstract class SyncHandler<S extends SyncHandler<S>> implements ISyncOrValue {
 
     private PanelSyncManager syncManager;
     private String key;
+    private boolean allowC2S;
 
     @ApiStatus.OverrideOnly
     @MustBeInvokedByOverriders
@@ -66,6 +69,10 @@ public abstract class SyncHandler implements ISyncOrValue {
      */
     @SideOnly(Side.CLIENT)
     public final void syncToServer(int id, @NotNull IPacketWriter bufferConsumer) {
+        if (!isAllowC2S()) {
+            ModularUI.LOGGER.throwing(Level.WARN, new SecurityException("Sync handler is unable to send packets to server!"));
+            return;
+        }
         PacketBuffer buffer = new PacketBuffer(Unpooled.buffer());
         buffer.writeVarIntToBuffer(id);
         try {
@@ -83,6 +90,10 @@ public abstract class SyncHandler implements ISyncOrValue {
      * @param bufferConsumer the package builder
      */
     public final void sync(int id, @NotNull IPacketWriter bufferConsumer) {
+        if (getSyncManager().isClient() && !isAllowC2S()) {
+            ModularUI.LOGGER.throwing(Level.WARN, new SecurityException("Sync handler is unable to send packets to server!"));
+            return;
+        }
         PacketBuffer buffer = new PacketBuffer(Unpooled.buffer());
         buffer.writeVarIntToBuffer(id);
         try {
@@ -183,6 +194,24 @@ public abstract class SyncHandler implements ISyncOrValue {
     @Override
     public boolean isSyncHandler() {
         return true;
+    }
+
+    public boolean isAllowC2S() {
+        return allowC2S;
+    }
+
+    public S allowC2S(boolean allowC2S) {
+        this.allowC2S = allowC2S;
+        return self();
+    }
+
+    public S allowC2S() {
+        return allowC2S(true);
+    }
+
+    @SuppressWarnings("unchecked")
+    public S self() {
+        return (S) this;
     }
 
     private static void send(ModularNetworkSide network, String panel, PacketBuffer buffer, SyncHandler syncHandler) {

--- a/src/main/java/com/cleanroommc/modularui/value/sync/SyncHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/SyncHandler.java
@@ -200,11 +200,26 @@ public abstract class SyncHandler<S extends SyncHandler<S>> implements ISyncOrVa
         return allowC2S;
     }
 
+    /**
+     * Sets this sync handler to accept C2S (client to server) packets. This value MUST be the same on client and server.
+     * By default, this is false to prevent clients from force updating values. Values which the player can control through a button for
+     * example are completely fine to allow C2S updates.
+     *
+     * @param allowC2S whether this sync handler should allow client to server updates
+     * @return this
+     */
     public S allowC2S(boolean allowC2S) {
         this.allowC2S = allowC2S;
         return self();
     }
 
+    /**
+     * Sets this sync handler whether to accept C2S (client to server) packets or not. This value MUST be the same on client and server.
+     * By default, this is false to prevent clients from force updating values. Values which the player can control through a button for
+     * example are completely fine to allow C2S updates.
+     *
+     * @return this
+     */
     public S allowC2S() {
         return allowC2S(true);
     }
@@ -214,7 +229,7 @@ public abstract class SyncHandler<S extends SyncHandler<S>> implements ISyncOrVa
         return (S) this;
     }
 
-    private static void send(ModularNetworkSide network, String panel, PacketBuffer buffer, SyncHandler syncHandler) {
+    private static void send(ModularNetworkSide network, String panel, PacketBuffer buffer, SyncHandler<?> syncHandler) {
         Objects.requireNonNull(buffer);
         Objects.requireNonNull(syncHandler);
         if (!syncHandler.isValid()) {
@@ -223,12 +238,12 @@ public abstract class SyncHandler<S extends SyncHandler<S>> implements ISyncOrVa
         network.sendSyncHandlerPacket(panel, syncHandler, buffer, syncHandler.syncManager.getPlayer());
     }
 
-    public static void sendToClient(String panel, PacketBuffer buffer, SyncHandler syncHandler) {
+    public static void sendToClient(String panel, PacketBuffer buffer, SyncHandler<?> syncHandler) {
         send(ModularNetwork.SERVER, panel, buffer, syncHandler);
     }
 
     @SideOnly(Side.CLIENT)
-    public static void sendToServer(String panel, PacketBuffer buffer, SyncHandler syncHandler) {
+    public static void sendToServer(String panel, PacketBuffer buffer, SyncHandler<?> syncHandler) {
         send(ModularNetwork.CLIENT, panel, buffer, syncHandler);
     }
 }

--- a/src/main/java/com/cleanroommc/modularui/value/sync/SyncHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/SyncHandler.java
@@ -2,6 +2,7 @@ package com.cleanroommc.modularui.value.sync;
 
 import com.cleanroommc.modularui.ModularUI;
 import com.cleanroommc.modularui.api.IPacketWriter;
+import com.cleanroommc.modularui.api.MCHelper;
 import com.cleanroommc.modularui.api.value.ISyncOrValue;
 import com.cleanroommc.modularui.network.ModularNetwork;
 import com.cleanroommc.modularui.network.ModularNetworkSide;
@@ -11,12 +12,16 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 import io.netty.buffer.Unpooled;
+
+import net.minecraft.util.ChatComponentText;
+
 import org.apache.logging.log4j.Level;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.MustBeInvokedByOverriders;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -71,6 +76,9 @@ public abstract class SyncHandler<S extends SyncHandler<S>> implements ISyncOrVa
     public final void syncToServer(int id, @NotNull IPacketWriter bufferConsumer) {
         if (!isAllowC2S()) {
             ModularUI.LOGGER.throwing(Level.WARN, new SecurityException("Sync handler is unable to send packets to server!"));
+            if (MCHelper.getPlayer() != null)
+                MCHelper.getPlayer().addChatMessage(new ChatComponentText("Sync handler is unable to send packets to server! " +
+                        "Please report this issue on Discord (or GitHub) with the fml-client-latest.log file attached!"));
             return;
         }
         PacketBuffer buffer = new PacketBuffer(Unpooled.buffer());
@@ -92,6 +100,9 @@ public abstract class SyncHandler<S extends SyncHandler<S>> implements ISyncOrVa
     public final void sync(int id, @NotNull IPacketWriter bufferConsumer) {
         if (getSyncManager().isClient() && !isAllowC2S()) {
             ModularUI.LOGGER.throwing(Level.WARN, new SecurityException("Sync handler is unable to send packets to server!"));
+            if (MCHelper.getPlayer() != null)
+                MCHelper.getPlayer().addChatMessage(new ChatComponentText("Sync handler is unable to send packets to server! " +
+                        "Please report this issue on Discord (or GitHub) with the fml-client-latest.log file attached!"));
             return;
         }
         PacketBuffer buffer = new PacketBuffer(Unpooled.buffer());

--- a/src/main/java/com/cleanroommc/modularui/value/sync/SyncHandlers.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/SyncHandlers.java
@@ -48,7 +48,7 @@ public class SyncHandlers {
         return new FluidSlotSyncHandler(fluidTank);
     }
 
-    public static <T extends Enum<T>> EnumSyncValue<T> enumValue(Class<T> clazz, Supplier<T> getter, Consumer<T> setter) {
+    public static <T extends Enum<T>> EnumSyncValue<T, ?> enumValue(Class<T> clazz, Supplier<T> getter, Consumer<T> setter) {
         return new EnumSyncValue<>(clazz, getter, setter);
     }
 

--- a/src/main/java/com/cleanroommc/modularui/value/sync/ValueSyncHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/ValueSyncHandler.java
@@ -6,7 +6,7 @@ import net.minecraft.network.PacketBuffer;
 
 import java.io.IOException;
 
-public abstract class ValueSyncHandler<T> extends SyncHandler implements IValueSyncHandler<T> {
+public abstract class ValueSyncHandler<T, S extends ValueSyncHandler<T, S>> extends SyncHandler<S> implements IValueSyncHandler<T> {
 
     public static final int SYNC_VALUE = 0;
 
@@ -43,6 +43,11 @@ public abstract class ValueSyncHandler<T> extends SyncHandler implements IValueS
 
     public void setChangeListener(Runnable changeListener) {
         this.changeListener = changeListener;
+    }
+
+    public S changeListener(Runnable changeListener) {
+        setChangeListener(changeListener);
+        return self();
     }
 
     public Runnable getChangeListener() {

--- a/src/main/java/com/cleanroommc/modularui/widget/Widget.java
+++ b/src/main/java/com/cleanroommc/modularui/widget/Widget.java
@@ -53,7 +53,7 @@ public class Widget<W extends Widget<W>> extends AbstractWidget implements IPosi
     // syncing
     @Nullable private IValue<?> value;
     @Nullable private String syncKey;
-    @Nullable private SyncHandler syncHandler;
+    @Nullable private SyncHandler<?> syncHandler;
     // rendering
     private boolean disableThemeBackground = false;
     private boolean disableHoverThemeBackground = false;
@@ -101,7 +101,7 @@ public class Widget<W extends Widget<W>> extends AbstractWidget implements IPosi
      */
     @Override
     public void initialiseSyncHandler(ModularSyncManager syncManager, boolean late) {
-        SyncHandler handler = this.syncHandler;
+        SyncHandler<?> handler = this.syncHandler;
         if (handler == null && this.syncKey != null) {
             handler = syncManager.getSyncHandler(getPanel().getName(), this.syncKey);
             if (handler == null && !syncManager.getMainPSM().getPanelName().equals(getPanel().getName())) {
@@ -109,7 +109,7 @@ public class Widget<W extends Widget<W>> extends AbstractWidget implements IPosi
             }
         }
         if (handler != null) setSyncOrValue(handler);
-        if (this.syncHandler instanceof ValueSyncHandler<?> valueSyncHandler && valueSyncHandler.getChangeListener() == null) {
+        if (this.syncHandler instanceof ValueSyncHandler<?, ?> valueSyncHandler && valueSyncHandler.getChangeListener() == null) {
             valueSyncHandler.setChangeListener(this::markTooltipDirty);
         }
     }
@@ -361,7 +361,6 @@ public class Widget<W extends Widget<W>> extends AbstractWidget implements IPosi
         return widgetTheme.getTheme(hover);
     }
 
-    @ApiStatus.NonExtendable
     @Override
     public final WidgetThemeEntry<?> getWidgetTheme(ITheme theme) {
         if (this.widgetThemeOverride != null) {
@@ -384,7 +383,6 @@ public class Widget<W extends Widget<W>> extends AbstractWidget implements IPosi
      * @throws IllegalStateException if the received widget theme type doesn't match the expected type
      */
     @SuppressWarnings("unchecked")
-    @ApiStatus.NonExtendable
     public final <T extends WidgetTheme> WidgetThemeEntry<T> getWidgetTheme(ITheme theme, Class<T> expectedType) {
         WidgetThemeEntry<?> entry = getWidgetTheme(theme);
         if (entry.getKey().isOfType(expectedType)) {
@@ -699,7 +697,7 @@ public class Widget<W extends Widget<W>> extends AbstractWidget implements IPosi
      * @throws IllegalStateException if this widget has no sync handler ({@link #isSynced()} returns false)
      */
     @Override
-    public @NotNull SyncHandler getSyncHandler() {
+    public @NotNull SyncHandler<?> getSyncHandler() {
         if (this.syncHandler == null) {
             throw new IllegalStateException("Widget is not initialised or not synced!");
         }
@@ -739,7 +737,7 @@ public class Widget<W extends Widget<W>> extends AbstractWidget implements IPosi
     @Deprecated
     protected void setValue(IValue<?> value) {
         this.value = value;
-        if (value instanceof SyncHandler handler) {
+        if (value instanceof SyncHandler<?> handler) {
             setSyncHandler(handler);
         }
     }
@@ -749,7 +747,7 @@ public class Widget<W extends Widget<W>> extends AbstractWidget implements IPosi
      */
     @ApiStatus.ScheduledForRemoval(inVersion = "3.2.0")
     @Deprecated
-    protected void setSyncHandler(@Nullable SyncHandler syncHandler) {
+    protected void setSyncHandler(@Nullable SyncHandler<?> syncHandler) {
         if (syncHandler != null) checkValidSyncOrValue(syncHandler);
         this.syncHandler = syncHandler;
     }
@@ -758,7 +756,7 @@ public class Widget<W extends Widget<W>> extends AbstractWidget implements IPosi
     protected void setSyncOrValue(@NotNull ISyncOrValue syncOrValue) {
         if (!syncOrValue.isSyncHandler() && !syncOrValue.isValueHandler()) return;
         checkValidSyncOrValue(syncOrValue);
-        if (syncOrValue instanceof SyncHandler syncHandler1) setSyncHandler(syncHandler1);
+        if (syncOrValue instanceof SyncHandler<?> syncHandler1) setSyncHandler(syncHandler1);
         if (syncOrValue instanceof IValue<?> value1) setValue(value1);
     }
 

--- a/src/main/java/com/cleanroommc/modularui/widgets/textfield/TextFieldWidget.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/textfield/TextFieldWidget.java
@@ -89,7 +89,7 @@ public class TextFieldWidget extends BaseTextFieldWidget<TextFieldWidget> {
     protected void setSyncOrValue(@NotNull ISyncOrValue syncOrValue) {
         super.setSyncOrValue(syncOrValue);
         this.stringValue = syncOrValue.castNullable(IStringValue.class);
-        if (syncOrValue instanceof ValueSyncHandler<?> valueSyncHandler) {
+        if (syncOrValue instanceof ValueSyncHandler<?, ?> valueSyncHandler) {
             valueSyncHandler.setChangeListener(() -> {
                 markTooltipDirty();
                 setText(this.stringValue.getValue().toString());


### PR DESCRIPTION
THIS WILL LIKELY BREAK SOME SYNC HANDLERS. You need to see if any of them require c2s packets and call the setter if they do. Additonally custom sync handler classes need the new generic type.