### PR TITLE
Fix NPE from map corruption when sync handlers register entries during init

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/value/sync/PanelSyncManager.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/PanelSyncManager.java
@@ -60,7 +60,13 @@ public class PanelSyncManager implements ISyncRegistrar<PanelSyncManager> {
     @ApiStatus.Internal
     public void initialize(String panelName) {
         this.panelName = panelName;
-        this.syncHandlers.forEach((mapKey, syncHandler) -> syncHandler.init(mapKey, this));
+        var snapshotKeys = new ArrayList<>(this.syncHandlers.keySet());
+        for (var mapKey : snapshotKeys) {
+            var syncHandler = this.syncHandlers.get(mapKey);
+            if (syncHandler != null) {
+                syncHandler.init(mapKey, this);
+            }
+        }
         this.locked = true;
         this.init = true;
         this.subPanels.forEach((s, syncHandler) -> this.modularSyncManager.getMainPSM().registerPanelSyncHandler(s, syncHandler));


### PR DESCRIPTION
PanelSyncManager.initialize() iterates over syncHandlers (an Object2ReferenceLinkedOpenHashMap) via forEach while calling init() on each handler. If a handler registers additional sync handlers during init() (e.g., GT5's GhostCircuitSyncHandler registering an IntSyncValue), the map is structurally modified during iteration. Unlike standard Java collections, fastutil's open-addressing maps don't throw ConcurrentModificationException, they fail silently, producing phantom null entries that cause an NPE. The fix snapshots the map's keys before iterating and looks up each value from the live map. Keys are immutable Strings, so the snapshot is always valid, and get() works correctly after any rehash. Entry objects can't be snapshotted because fastutil's MapEntry stores an internal array index that becomes stale after rehash.