### PR TITLE
Fix crash in PanelSyncHandler and TextFieldHandler

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/value/sync/PanelSyncHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/PanelSyncHandler.java
@@ -112,8 +112,11 @@ public final class PanelSyncHandler extends SyncHandler<PanelSyncHandler> implem
     @ApiStatus.Internal
     @Override
     public void closePanelInternal() {
-        getSyncManager().getModularSyncManager().close(this.panelName);
         this.open = false;
+        // Sync infrastructure may already be torn down if the screen was disposed
+        // (e.g. deferred PanelManager.dispose() running after ModularNetwork.closeAll())
+        if (!isValid()) return;
+        getSyncManager().getModularSyncManager().close(this.panelName);
         if (getSyncManager().isClient()) {
             syncToServer(SYNC_CLOSE);
         }

--- a/src/main/java/com/cleanroommc/modularui/widgets/textfield/TextFieldHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/textfield/TextFieldHandler.java
@@ -304,8 +304,10 @@ public class TextFieldHandler {
             text.addAll(insertion);
             return new Point(text.get(text.size() - 1).length(), text.size() - 1);
         }
-        String lineStart = text.get(this.cursor.y).substring(0, this.cursor.x);
-        String lineEnd = text.get(this.cursor.y).substring(this.cursor.x);
+        String line = text.get(this.cursor.y);
+        int cursorX = Math.min(this.cursor.x, line.length());
+        String lineStart = line.substring(0, cursorX);
+        String lineEnd = line.substring(cursorX);
         if (insertion.size() == 1 && text.size() == 1 && !test(lineStart + insertion.get(0) + lineEnd)) {
             return null;
         }
@@ -315,7 +317,7 @@ public class TextFieldHandler {
                 return null;
             }
             text.set(this.cursor.y, text.get(this.cursor.y) + lineEnd);
-            return new Point(this.cursor.x + insertion.get(0).length(), this.cursor.y);
+            return new Point(cursorX + insertion.get(0).length(), this.cursor.y);
         } else {
             text.add(this.cursor.y + 1, insertion.get(insertion.size() - 1) + lineEnd);
             x = insertion.get(insertion.size() - 1).length();


### PR DESCRIPTION
Fix "IllegalStateException: Sync handler is not yet initialised!" in PanelSyncHandler.closePanelInternal() when closing a GUI during a mouse press event. The root cause is a timing issue: ModularNetwork.CLIENT.closeAll() disposes sync handlers immediately while PanelManager.dispose() is deferred by cantDisposeNow, so by the time deferred disposal finalizes panels, their sync handlers are already dead. The fix makes closePanelInternal skip sync operations when the sync infrastructure is already torn down.

Fix StringIndexOutOfBoundsException in TextFieldHandler.insert() when cursor.x exceeds the current line length, by clamping the cursor position to the line bounds before substring operations.

Tested on server