### PR TITLE
Fix gather problem

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/core/mixins/early/minecraft/GuiContainerMixin.java
+++ b/src/main/java/com/cleanroommc/modularui/core/mixins/early/minecraft/GuiContainerMixin.java
@@ -2,8 +2,11 @@ package com.cleanroommc.modularui.core.mixins.early.minecraft;
 
 import com.cleanroommc.modularui.api.IMuiScreen;
 import com.cleanroommc.modularui.screen.IClickableGuiContainer;
+import com.cleanroommc.modularui.widgets.slot.ModularSlot;
+import com.cleanroommc.modularui.widgets.slot.SlotGroup;
 
 import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
 
 import org.spongepowered.asm.lib.Opcodes;
@@ -13,6 +16,7 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(GuiContainer.class)
@@ -58,5 +62,18 @@ public class GuiContainerMixin implements IClickableGuiContainer {
             at = @At(value = "FIELD", opcode = Opcodes.GETFIELD, target = "Lnet/minecraft/inventory/Slot;slotNumber:I"), ordinal = 1)
     protected boolean mouseClickedOnSlot(boolean flag1) {
         return false;
+    }
+
+    @Redirect(
+            method = "mouseMovedOrUp",
+            at = @At(value = "FIELD", opcode = Opcodes.GETFIELD, target = "Lnet/minecraft/inventory/Slot;inventory:Lnet/minecraft/inventory/IInventory;")
+    )
+    private IInventory checkSlotGroup(Slot slot) {
+        if (slot instanceof ModularSlot ms) {
+            SlotGroup slotGroup = ms.getSlotGroup();
+            if (slotGroup == null) return null;
+            return slotGroup.getDummyInventoryForComparison();
+        }
+        return slot.inventory;
     }
 }

--- a/src/main/java/com/cleanroommc/modularui/widgets/slot/SlotGroup.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/slot/SlotGroup.java
@@ -1,5 +1,7 @@
 package com.cleanroommc.modularui.widgets.slot;
 
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.InventoryBasic;
 import net.minecraft.inventory.Slot;
 
 import org.jetbrains.annotations.ApiStatus;
@@ -27,6 +29,7 @@ public class SlotGroup {
     private final boolean allowShiftTransfer;
     private boolean allowSorting = true;
     private final boolean singleton;
+    private final IInventory dummyInventory = new InventoryBasic("[Null]", true, 0);
 
     /**
      * Creates a slot group that is only a single slot. Singleton groups don't need to be registered.
@@ -116,5 +119,10 @@ public class SlotGroup {
     public SlotGroup setAllowSorting(boolean allowSorting) {
         this.allowSorting = allowSorting;
         return this;
+    }
+
+    @ApiStatus.Internal
+    public IInventory getDummyInventoryForComparison() {
+        return dummyInventory;
     }
 }


### PR DESCRIPTION
Vanilla shift double click rely on object comparison of the underlying inventory, which is dynamically set in `ModularSlot`. This PR expose a dummy inventory for object comparison to function based on the underlying slot group.

Both clip test feature in the order of:
1. shift double click existing stack when inv is full
2. shift double click with stack held on both inventory

Before:

https://github.com/user-attachments/assets/afb56820-1e21-4832-9fa5-a16bf7ac5d05


After:

https://github.com/user-attachments/assets/eeaf7a96-58ca-427b-92c6-eb36e9c47625



Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25006