### PR TITLE
Add check for "." being parsed with exponent E

### DIFF
--- a/src/main/java/com/ezylang/evalex/data/EvaluationValue.java
+++ b/src/main/java/com/ezylang/evalex/data/EvaluationValue.java
@@ -372,6 +372,11 @@ public class EvaluationValue implements Comparable<EvaluationValue> {
         if (value.startsWith("0x") || value.startsWith("0X")) {
             BigInteger hexToInteger = new BigInteger(value.substring(2), 16);
             return EvaluationValue.numberValue(new BigDecimal(hexToInteger, mathContext));
+        } else if (value.toLowerCase().contains("e")) {
+            if (value.toLowerCase().split("e")[1].contains(".")) {
+                return EvaluationValue.numberValue(new BigDecimal(0, mathContext));
+            }
+            return EvaluationValue.numberValue(new BigDecimal(value, mathContext));
         } else {
             return EvaluationValue.numberValue(new BigDecimal(value, mathContext));
         }


### PR DESCRIPTION
As mentioned in GTNH discord https://discord.com/channels/181078474394566657/1303308397961019472/1513223411009327419

BigDecimal parser crashes when it's given string like "1E9.0" because "." is not a digit. Adds a check inside `numberOfString` so this doesn't happen, works for complex stuff like `5+1e5.0+15*1.8`, where it fails and zeroes only `1e5.0` part. Another way would be to add the checks to `parseExpressionWholeNumber` and `parseExpression`, in which case i think it would fail the entire string and return 0.
Unless i am understanding it wrong, second option would be "faster" because we have less if else statements in the `numberOfString` that gets called for each number in the expression at the "cost" of failing the entire string.