### PR TITLE
Restore GL state after untextured draws (fixes white NEI items)

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/drawable/GuiDraw.java
+++ b/src/main/java/com/cleanroommc/modularui/drawable/GuiDraw.java
@@ -48,6 +48,7 @@ public class GuiDraw {
         Platform.startDrawing(Platform.DrawMode.QUADS, Platform.VertexFormat.POS_COLOR, bufferBuilder -> {
             drawRectRaw(bufferBuilder, x0, y0, x0 + w, y0 + h, color);
         });
+        Platform.endDrawColor();
     }
 
     public static void drawHorizontalGradientRect(float x0, float y0, float w, float h, int colorLeft, int colorRight) {
@@ -69,6 +70,7 @@ public class GuiDraw {
             bufferBuilder.pos(x1, y0, 0.0f).color(Color.getRed(colorTR), Color.getGreen(colorTR), Color.getBlue(colorTR), Color.getAlpha(colorTR)).endVertex();
         });
         Platform.endDrawGradient();
+        Platform.endDrawColor();
     }
 
     public static void drawRectRaw(BufferBuilder buffer, float x0, float y0, float x1, float y1, int color) {
@@ -115,6 +117,7 @@ public class GuiDraw {
             }
         });
         Platform.endDrawGradient();
+        Platform.endDrawColor();
     }
 
     public static void drawRoundedRect(float x0, float y0, float w, float h, int color, int cornerRadius, int segments) {
@@ -173,6 +176,7 @@ public class GuiDraw {
             bufferBuilder.pos(x0, y0 + cornerRadius, 0.0f).color(Color.getRed(colorTL), Color.getGreen(colorTL), Color.getBlue(colorTL), Color.getAlpha(colorTL)).endVertex();
         });
         Platform.endDrawGradient();
+        Platform.endDrawColor();
     }
 
     public static void drawTexture(ResourceLocation location, float x, float y, float w, float h, int u, int v, int textureWidth, int textureHeight) {
@@ -515,6 +519,7 @@ public class GuiDraw {
             pc(buffer, x0, y0, color);
             pc(buffer, x1 - d, y0 + d, color);
         });
+        Platform.endDrawColor();
     }
 
     public static void drawBorderOutsideLTRB(float left, float top, float right, float bottom, int color) {
@@ -616,6 +621,7 @@ public class GuiDraw {
             bufferBuilder.pos(x1 + oX, y1 + oY, 0).color(r2, g2, b2, a2).endVertex();
         });
         Platform.endDrawGradient();
+        Platform.endDrawColor();
     }
 
     public static void drawDropCircleShadow(int x, int y, int radius, int segments, int opaque, int shadow) {
@@ -640,6 +646,7 @@ public class GuiDraw {
             }
         });
         Platform.endDrawGradient();
+        Platform.endDrawColor();
     }
 
     public static void drawDropCircleShadow(int x, int y, int radius, int offset, int segments, int opaque, int shadow) {
@@ -677,6 +684,7 @@ public class GuiDraw {
             }
         });
         Platform.endDrawGradient();
+        Platform.endDrawColor();
     }
 
     @ApiStatus.ScheduledForRemoval(inVersion = "3.2.0")

--- a/src/main/java/com/cleanroommc/modularui/drawable/Rectangle.java
+++ b/src/main/java/com/cleanroommc/modularui/drawable/Rectangle.java
@@ -161,6 +161,7 @@ public class Rectangle implements IDrawable, IJsonSerializable, IAnimatable<Rect
                 v(buffer, x1 - d, y0 + d, this.colorTR);
             });
             Platform.endDrawGradient();
+            Platform.endDrawColor();
         }
     }
 

--- a/src/main/java/com/cleanroommc/modularui/screen/ClientScreenHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/ClientScreenHandler.java
@@ -445,6 +445,7 @@ public class ClientScreenHandler {
         RenderHelper.enableStandardItemLighting();
         handleAnimationScale(mcScreen);
         muiScreen.drawScreen();
+        Platform.setupDrawTex();
         GlStateManager.disableLighting();
         GlStateManager.disableDepth();
         drawVanillaElements(mcScreen, mouseX, mouseY, partialTicks);
@@ -474,6 +475,7 @@ public class ClientScreenHandler {
         //handleAnimationScale(mcScreen);
         acc.invokeDrawGuiContainerBackgroundLayer(partialTicks, mouseX, mouseY);
         muiScreen.drawScreen();
+        Platform.setupDrawTex();
 
         GlStateManager.disableLighting();
         GlStateManager.disableDepth();

--- a/src/main/java/com/cleanroommc/modularui/utils/Platform.java
+++ b/src/main/java/com/cleanroommc/modularui/utils/Platform.java
@@ -70,6 +70,17 @@ public class Platform {
         GlStateManager.disableAlpha();
     }
 
+    /**
+     * Restores the GL state changed by {@link #setupDrawColor()} to the default GUI state,
+     * like vanilla {@link net.minecraft.client.gui.Gui#drawRect} does.
+     * External code (NEI, vanilla buttons, foreground layers) expects this state.
+     */
+    public static void endDrawColor() {
+        GlStateManager.enableTexture2D();
+        GlStateManager.enableAlpha();
+        GlStateManager.disableBlend();
+    }
+
     public static void setupDrawTex(ResourceLocation texture) {
         setupDrawTex(texture, false);
     }

--- a/src/main/java/com/cleanroommc/modularui/widgets/textfield/TextFieldRenderer.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/textfield/TextFieldRenderer.java
@@ -259,5 +259,6 @@ public class TextFieldRenderer extends TextRenderer {
             bufferBuilder.pos(x0, y0, 0.0D).endVertex();
         });
         GlStateManager.color(1, 1, 1, 1);
+        Platform.endDrawColor();
     }
 }


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25499

## Summary
See issue comments
Restore GL state properly after draws. To prevent other mods getting it in an unexpected state.

Before:
<img width="2560" height="1369" alt="image" src="https://github.com/user-attachments/assets/2721d33b-6e5c-4a95-b027-ae61df0b6eca" />
After:
<img width="2560" height="1369" alt="javaw_FBF8Db4cfP" src="https://github.com/user-attachments/assets/51a2cbb0-776a-4fac-b20e-a0a330c13526" />



## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
