### PR TITLE
Long-Fluid Support GUI Fix

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation("com.github.GTNewHorizons:NotEnoughItems:2.8.105-GTNH:dev")
     compileOnly("com.github.GTNewHorizons:Hodgepodge:2.7.165:dev") { transitive = false }
     
-    devOnlyNonPublishable("com.github.GTNewHorizons:GT5-Unofficial:5.09.53.07:dev") {
+    devOnlyNonPublishable("com.github.GTNewHorizons:GT5-Unofficial:5.09.54.27:dev") {
         exclude group: 'com.github.GTNewHorizons', module: 'ModularUI2'
     }
     

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -1,5 +1,5 @@
 // Add any additional repositories for your dependencies here
 
 repositories {
-
+    mavenLocal()
 }

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -1,5 +1,5 @@
 // Add any additional repositories for your dependencies here
 
 repositories {
-    mavenLocal()
+
 }

--- a/src/main/java/com/cleanroommc/modularui/network/NetworkUtils.java
+++ b/src/main/java/com/cleanroommc/modularui/network/NetworkUtils.java
@@ -19,6 +19,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.function.Consumer;
 
+import gregtech.api.util.GTUtility;
+
 public class NetworkUtils {
 
     public static final Consumer<PacketBuffer> EMPTY_PACKET = buffer -> {};
@@ -91,6 +93,7 @@ public class NetworkUtils {
             return null;
         }
         try {
+            if (ModularUI.Mods.GT5U.isLoaded()) return GTUtility.loadFluid(buffer.readNBTTagCompoundFromBuffer());
             return FluidStack.loadFluidStackFromNBT(buffer.readNBTTagCompoundFromBuffer());
         } catch (IOException e) {
             ModularUI.LOGGER.catching(e);

--- a/src/main/java/com/cleanroommc/modularui/widgets/AbstractFluidDisplayWidget.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/AbstractFluidDisplayWidget.java
@@ -48,7 +48,7 @@ public abstract class AbstractFluidDisplayWidget<W extends AbstractFluidDisplayW
         int h = getArea().height - this.contentPadding.vertical();
         float c = getCapacity();
         if (c > 0 && fluid.amount > 0) {
-            int newH = (int) MathUtils.rescaleLinear(fluid.amount, 0, c, 1, h);
+            int newH = (int) MathUtils.rescaleLinear(getFluidAmountLong(), 0, c, 1, h);
             // 1.12 has a method called isLighterThanAir(), using isGaseous() as a replacement here
             if (!this.flipLighterThanAir || !fluid.getFluid().isGaseous()) y += h - newH;
             h = newH;
@@ -61,7 +61,7 @@ public abstract class AbstractFluidDisplayWidget<W extends AbstractFluidDisplayW
         super.drawOverlay(context, widgetTheme);
         FluidStack fluid = getFluidStack();
         if (fluid != null && displayAmountText()) {
-            String s = NumberFormat.format(getBaseUnitAmount(fluid.amount), NumberFormat.AMOUNT_TEXT) + getBaseUnit();
+            String s = NumberFormat.format(getBaseUnitAmount(getFluidAmountLong()), NumberFormat.AMOUNT_TEXT) + getBaseUnit();
             // mc doesn't consider the 1px border in item slots for amount text, but it looks weird when it touches the left border, so
             // we only apply padding there
             GuiDraw.drawScaledAlignedTextInBox(s, this.contentPadding.getLeft(), 0, getArea().width - this.contentPadding.getLeft(), getArea().height, Alignment.BottomRight);
@@ -72,6 +72,14 @@ public abstract class AbstractFluidDisplayWidget<W extends AbstractFluidDisplayW
 
     @Nullable
     protected abstract FluidStack getFluidStack();
+
+    protected long getFluidAmountLong() {
+        FluidStack stack = getFluidStack();
+        if (stack == null) return 0;
+
+        if (ModularUI.Mods.GT5U.isLoaded()) return GTUtility.getFluidAmount(stack);
+        return stack.amount;
+    };
 
     @Override
     public @Nullable ItemStack getStackForRecipeViewer() {


### PR DESCRIPTION
## Summary
A GUI Fix for GTNewHorizons/GT5-Unofficial#7384

Adds support to retrieve long amount of fluid from gt FluidStack

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [x] This PR requires another PR in order to merge
  - [ ] GTNewHorizons/GT5-Unofficial#7384
