### PR TITLE
Fix fluid display widget rendering empty FluidStacks as full

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/widgets/AbstractFluidDisplayWidget.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/AbstractFluidDisplayWidget.java
@@ -41,13 +41,13 @@ public abstract class AbstractFluidDisplayWidget<W extends AbstractFluidDisplayW
     @Override
     public void draw(ModularGuiContext context, WidgetThemeEntry<?> widgetTheme) {
         FluidStack fluid = getFluidStack();
-        if (fluid == null) return;
+        if (fluid == null || fluid.amount <= 0) return;
         int x = this.contentPadding.getLeft();
         int y = this.contentPadding.getTop();
         int w = getArea().width - this.contentPadding.horizontal();
         int h = getArea().height - this.contentPadding.vertical();
         float c = getCapacity();
-        if (c > 0 && fluid.amount > 0) {
+        if (c > 0) {
             int newH = (int) MathUtils.rescaleLinear(fluid.amount, 0, c, 1, h);
             // 1.12 has a method called isLighterThanAir(), using isGaseous() as a replacement here
             if (!this.flipLighterThanAir || !fluid.getFluid().isGaseous()) y += h - newH;


### PR DESCRIPTION
## Summary
Early return for `fluid.amount <= 0` so the fluid texture is not rendered for empty FluidStacks. Removed the `fluid.amount > 0` check later because it will be always true.

## Checklist
- [ ] I have tested this PR in DevEnv
- [X] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
