### PR TITLE
Fix explicit percentages in bounded number fields

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/utils/MathUtils.java
+++ b/src/main/java/com/cleanroommc/modularui/utils/MathUtils.java
@@ -257,6 +257,16 @@ public class MathUtils {
         return Math.round(value * maxValue);
     }
 
+    /**
+     * Resolves a parsed bounded value while preserving an explicit percentage in the source expression.
+     */
+    public static long percentOrSelf(String expression, double value, long maxValue) {
+        if (expression != null && expression.indexOf('%') >= 0) {
+            return Math.round(value * maxValue);
+        }
+        return percentOrSelf(value, maxValue);
+    }
+
     public static int castToIntSaturated(long l) {
         if (l >= Integer.MAX_VALUE) return Integer.MAX_VALUE;
         if (l <= Integer.MIN_VALUE) return Integer.MIN_VALUE;

--- a/src/main/java/com/cleanroommc/modularui/widgets/textfield/TextFieldWidget.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/textfield/TextFieldWidget.java
@@ -22,7 +22,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.text.ParseException;
 import java.text.ParsePosition;
-import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.DoubleSupplier;
 import java.util.function.Function;
@@ -249,7 +248,13 @@ public class TextFieldWidget extends BaseTextFieldWidget<TextFieldWidget> {
         return numbersDouble((input, num) -> validator.apply(num));
     }
 
-    private TextFieldWidget numbersDouble(BiFunction<String, Double, Double> validator) {
+    @FunctionalInterface
+    private interface NumberValidator {
+
+        double apply(String input, double value);
+    }
+
+    private TextFieldWidget numbersDouble(NumberValidator validator) {
         this.numbers = true;
         return setValidator(val -> {
             double num;
@@ -313,7 +318,7 @@ public class TextFieldWidget extends BaseTextFieldWidget<TextFieldWidget> {
             if (min != null) {
                 l = Math.max(l, min.getAsLong());
             }
-            return (double) l;
+            return l;
         });
     }
 

--- a/src/main/java/com/cleanroommc/modularui/widgets/textfield/TextFieldWidget.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/textfield/TextFieldWidget.java
@@ -22,6 +22,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.text.ParseException;
 import java.text.ParsePosition;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.DoubleSupplier;
 import java.util.function.Function;
@@ -245,6 +246,10 @@ public class TextFieldWidget extends BaseTextFieldWidget<TextFieldWidget> {
     }
 
     public TextFieldWidget numbersDouble(DAM.UnaryDoubleOperator validator) {
+        return numbersDouble((input, num) -> validator.apply(num));
+    }
+
+    private TextFieldWidget numbersDouble(BiFunction<String, Double, Double> validator) {
         this.numbers = true;
         return setValidator(val -> {
             double num;
@@ -253,7 +258,7 @@ public class TextFieldWidget extends BaseTextFieldWidget<TextFieldWidget> {
             } else {
                 num = parse(val);
             }
-            return format.format(validator.apply(num));
+            return format.format(validator.apply(val, num));
         });
     }
 
@@ -289,17 +294,18 @@ public class TextFieldWidget extends BaseTextFieldWidget<TextFieldWidget> {
      *
      * @param validator allow further validation of the number
      * @param min       optional lower limit
-     * @param max       optional upper limit, if this is specified, then values that evaluate to a noninteger are multiplied by the max
+     * @param max       optional upper limit, if this is specified, then explicit percentages and fractional values are
+     *                  multiplied by the max
      */
     public TextFieldWidget numbersLong(MathUtils.UnaryLongOperator validator, @Nullable LongSupplier min, @Nullable LongSupplier max) {
         formatAsInteger(true);
         defaultWholeNumberScrollValues();
         numberParser(MathUtils.PARSER_WHOLE_NUMBER);
-        return numbersDouble(d -> {
+        return numbersDouble((val, d) -> {
             long l;
             if (max != null) {
                 long maxValue = max.getAsLong();
-                l = MathUtils.percentOrSelf(d, maxValue);
+                l = MathUtils.percentOrSelf(val, d, maxValue);
                 l = Math.min(validator.apply(l), maxValue);
             } else {
                 l = validator.apply(Math.round(d));
@@ -307,7 +313,7 @@ public class TextFieldWidget extends BaseTextFieldWidget<TextFieldWidget> {
             if (min != null) {
                 l = Math.max(l, min.getAsLong());
             }
-            return l;
+            return (double) l;
         });
     }
 

--- a/src/main/java/com/cleanroommc/modularui/widgets/textfield/TextFieldWidget.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/textfield/TextFieldWidget.java
@@ -249,12 +249,12 @@ public class TextFieldWidget extends BaseTextFieldWidget<TextFieldWidget> {
     }
 
     @FunctionalInterface
-    private interface NumberValidator {
+    public interface NumberValidator {
 
         double apply(String input, double value);
     }
 
-    private TextFieldWidget numbersDouble(NumberValidator validator) {
+    public TextFieldWidget numbersDouble(NumberValidator validator) {
         this.numbers = true;
         return setValidator(val -> {
             double num;

--- a/src/test/java/com/cleanroommc/modularui/utils/MathUtilsTest.java
+++ b/src/test/java/com/cleanroommc/modularui/utils/MathUtilsTest.java
@@ -1,0 +1,17 @@
+package com.cleanroommc.modularui.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MathUtilsTest {
+
+    @Test
+    void testExplicitPercentageRelativeToMaximum() {
+        assertEquals(1, MathUtils.percentOrSelf("1", 1, 256));
+        assertEquals(128, MathUtils.percentOrSelf("0.5", 0.5, 256));
+        assertEquals(128, MathUtils.percentOrSelf("50%", 0.5, 256));
+        assertEquals(256, MathUtils.percentOrSelf("100%", 1, 256));
+        assertEquals(512, MathUtils.percentOrSelf("200%", 2, 256));
+    }
+}


### PR DESCRIPTION
## Summary
Fixes bounded numeric text fields interpreting `100%` as the absolute value `1` instead of the configured maximum.

The original input expression is now preserved during validation, allowing explicit percentages to be distinguished from ordinary numeric values:

- `1` remains `1`
- `50%` resolves to half the maximum
- `100%` resolves to the maximum

Includes regression tests covering absolute, fractional, and explicit percentage inputs.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
