### PR TITLE
Promote ModularUI1 dep to compileOnlyApi

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -45,7 +45,7 @@ dependencies {
         exclude group: 'com.github.GTNewHorizons', module: 'ModularUI2'
     }
     
-    compileOnly("com.github.GTNewHorizons:ModularUI:1.3.4:dev") { transitive = false }
+    compileOnlyApi("com.github.GTNewHorizons:ModularUI:1.3.4:dev") { transitive = false }
     implementation("com.github.GTNewHorizons:Baubles-Expanded:2.2.21-GTNH:dev")  { transitive = false }
     compileOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev")
     compileOnlyApi rfg.deobf("curse.maven:neverenoughanimation-1062347:7664003-sources-7663978")


### PR DESCRIPTION
## Summary
This will make mui1 available for dependent mods at compile time. needed because `IItemHandler` and `IItemHandlerModifiable` extend their mui1 equivalents, meaning that anything that extends them also extends the mui1 equivalents at compile time.


## Checklist
- ✅ I have tested this PR in DevEnv
- ❌ I have tested this PR in Fullpack
- ✅ This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- ❌ This PR requires another PR in order to merge
