### PR TITLE
Improve error logging for cycle button out of bounds

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/widgets/AbstractCycleButtonWidget.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/AbstractCycleButtonWidget.java
@@ -132,7 +132,7 @@ public class AbstractCycleButtonWidget<W extends AbstractCycleButtonWidget<W>> e
 
     public void setState(int state, boolean setSource) {
         if (state < 0 || state >= this.stateCount) {
-            throw new IndexOutOfBoundsException("CycleButton state out of bounds");
+            throw new IndexOutOfBoundsException("CycleButton state " + state + " out of bounds for length " + stateCount);
         }
         updateChild(state);
         if (setSource) {


### PR DESCRIPTION
## Summary
Show the errored state and the maximum state, similar to an array IndexOutOfBoundsException. Helps debug.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
