### PR TITLE
Allow Panel and Screen Creation to Fail

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/api/UIFactory.java
+++ b/src/main/java/com/cleanroommc/modularui/api/UIFactory.java
@@ -15,6 +15,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * An interface for UI factories. They are responsible for opening synced GUIs and syncing necessary data.
@@ -41,7 +42,7 @@ public interface UIFactory<D extends GuiData> {
      * @return new main panel
      */
     @ApiStatus.OverrideOnly
-    ModularPanel createPanel(D guiData, PanelSyncManager syncManager, UISettings settings);
+    @Nullable ModularPanel createPanel(D guiData, PanelSyncManager syncManager, UISettings settings);
 
     /**
      * Creates the screen for the GUI. Is only called on client side.
@@ -52,7 +53,7 @@ public interface UIFactory<D extends GuiData> {
      */
     @SideOnly(Side.CLIENT)
     @ApiStatus.OverrideOnly
-    ModularScreen createScreen(D guiData, ModularPanel mainPanel);
+    @Nullable ModularScreen createScreen(D guiData, ModularPanel mainPanel);
 
     /**
      * Creates the screen wrapper for the GUI. Is only called on client side.

--- a/src/main/java/com/cleanroommc/modularui/factory/AbstractUIFactory.java
+++ b/src/main/java/com/cleanroommc/modularui/factory/AbstractUIFactory.java
@@ -12,6 +12,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 
@@ -40,19 +41,18 @@ public abstract class AbstractUIFactory<T extends GuiData> implements UIFactory<
         return this.name;
     }
 
-    @NotNull
-    public abstract IGuiHolder<T> getGuiHolder(T data);
+    public abstract @Nullable IGuiHolder<T> getGuiHolder(T data);
 
     @Override
-    public ModularPanel createPanel(T guiData, PanelSyncManager syncManager, UISettings settings) {
-        IGuiHolder<T> guiHolder = Objects.requireNonNull(getGuiHolder(guiData), "Gui holder must not be null!");
-        return guiHolder.buildUI(guiData, syncManager, settings);
+    public @Nullable ModularPanel createPanel(T guiData, PanelSyncManager syncManager, UISettings settings) {
+        IGuiHolder<T> guiHolder = getGuiHolder(guiData);
+        return guiHolder == null ? null : guiHolder.buildUI(guiData, syncManager, settings);
     }
 
     @Override
-    public ModularScreen createScreen(T guiData, ModularPanel mainPanel) {
-        IGuiHolder<T> guiHolder = Objects.requireNonNull(getGuiHolder(guiData), "Gui holder must not be null!");
-        return guiHolder.createScreen(guiData, mainPanel);
+    public @Nullable ModularScreen createScreen(T guiData, ModularPanel mainPanel) {
+        IGuiHolder<T> guiHolder = getGuiHolder(guiData);
+        return guiHolder == null ? null : guiHolder.createScreen(guiData, mainPanel);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/com/cleanroommc/modularui/factory/GuiManager.java
+++ b/src/main/java/com/cleanroommc/modularui/factory/GuiManager.java
@@ -77,6 +77,7 @@ public class GuiManager {
         ModularSyncManager msm = new ModularSyncManager(false);
         PanelSyncManager syncManager = new PanelSyncManager(msm, true);
         ModularPanel panel = factory.createPanel(guiData, syncManager, settings);
+        if (panel == null) return;
         WidgetTree.collectSyncValues(syncManager, panel);
         ModularContainer container = settings.hasCustomContainer() ? settings.createContainer() : factory.createContainer();
         container.construct(player, msm, settings, panel.getName(), guiData);
@@ -106,8 +107,10 @@ public class GuiManager {
         ModularSyncManager msm = new ModularSyncManager(true);
         PanelSyncManager syncManager = new PanelSyncManager(msm, true);
         ModularPanel panel = factory.createPanel(guiData, syncManager, settings);
+        if (panel == null) return;
         WidgetTree.collectSyncValues(syncManager, panel);
         ModularScreen screen = factory.createScreen(guiData, panel);
+        if (screen == null) return;
         screen.getContext().setSettings(settings);
         ModularContainer container = settings.hasCustomContainer() ? settings.createContainer() : factory.createContainer();
         container.construct(player, msm, settings, panel.getName(), guiData);

--- a/src/main/java/com/cleanroommc/modularui/factory/GuiManager.java
+++ b/src/main/java/com/cleanroommc/modularui/factory/GuiManager.java
@@ -107,10 +107,10 @@ public class GuiManager {
         ModularSyncManager msm = new ModularSyncManager(true);
         PanelSyncManager syncManager = new PanelSyncManager(msm, true);
         ModularPanel panel = factory.createPanel(guiData, syncManager, settings);
-        if (panel == null) return;
+        if (panel == null) throw new IllegalStateException("Panel must not be null on Client when Panel was not null on Server!");
         WidgetTree.collectSyncValues(syncManager, panel);
         ModularScreen screen = factory.createScreen(guiData, panel);
-        if (screen == null) return;
+        if (screen == null) throw new IllegalStateException("Screen must not be null on Client when Screen was not null on Server!");
         screen.getContext().setSettings(settings);
         ModularContainer container = settings.hasCustomContainer() ? settings.createContainer() : factory.createContainer();
         container.construct(player, msm, settings, panel.getName(), guiData);


### PR DESCRIPTION
## Summary
Change `NotNull` to `Nullable` contract for creating panels and screens.
Cancels opening GUI upon a null panel or screen.

Adaptation in gt5u: [Adapt to MUI2 getGuiHolder Change- #7613](https://github.com/GTNewHorizons/GT5-Unofficial/pull/7613).

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [x] This PR requires another PR in order to merge
