### PR TITLE
Take the fluid unit from GTNHLib instead of hardcoding L

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/widgets/AbstractFluidDisplayWidget.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/AbstractFluidDisplayWidget.java
@@ -16,7 +16,7 @@ import com.cleanroommc.modularui.widget.sizer.Box;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
-import com.gtnewhorizon.gtnhlib.util.numberformatting.NumberFormatUtil;
+import com.gtnewhorizon.gtnhlib.util.numberformatting.NumberFormatConfig;
 import gregtech.api.util.GTUtility;
 import org.jetbrains.annotations.Nullable;
 
@@ -27,7 +27,7 @@ public abstract class AbstractFluidDisplayWidget<W extends AbstractFluidDisplayW
 
     private final Box contentPadding = new Box().all(1);
     private @Nullable String unit = null;
-    private SIPrefix baseUnitPrefix = SIPrefix.One;
+    private @Nullable SIPrefix baseUnitPrefix = null;
     private boolean flipLighterThanAir = true;
 
     protected AbstractFluidDisplayWidget() {
@@ -100,14 +100,20 @@ public abstract class AbstractFluidDisplayWidget<W extends AbstractFluidDisplayW
     }
 
     /**
-     * @return the explicitly set unit, or the fluid unit configured in GTNHLib (mB or L) if none was set
+     * @return the explicitly set base unit, or the one matching the fluid unit configured in GTNHLib
      */
     public String getBaseUnit() {
-        return this.unit != null ? this.unit : NumberFormatUtil.getFluidUnit();
+        if (this.unit != null) return this.unit;
+        return usesMilliBuckets() ? UNIT_BUCKET : UNIT_LITER;
     }
 
     public SIPrefix getBaseUnitSiPrefix() {
-        return this.baseUnitPrefix;
+        if (this.baseUnitPrefix != null) return this.baseUnitPrefix;
+        return usesMilliBuckets() ? SIPrefix.Milli : SIPrefix.One;
+    }
+
+    private boolean usesMilliBuckets() {
+        return NumberFormatConfig.useForgeFluidMillibuckets;
     }
 
     public boolean isFlipLighterThanAir() {

--- a/src/main/java/com/cleanroommc/modularui/widgets/AbstractFluidDisplayWidget.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/AbstractFluidDisplayWidget.java
@@ -16,6 +16,7 @@ import com.cleanroommc.modularui.widget.sizer.Box;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
+import com.gtnewhorizon.gtnhlib.util.numberformatting.NumberFormatUtil;
 import gregtech.api.util.GTUtility;
 import org.jetbrains.annotations.Nullable;
 
@@ -25,7 +26,7 @@ public abstract class AbstractFluidDisplayWidget<W extends AbstractFluidDisplayW
     public static final String UNIT_LITER = "L";
 
     private final Box contentPadding = new Box().all(1);
-    private String unit = UNIT_LITER;
+    private @Nullable String unit = null;
     private SIPrefix baseUnitPrefix = SIPrefix.One;
     private boolean flipLighterThanAir = true;
 
@@ -98,8 +99,11 @@ public abstract class AbstractFluidDisplayWidget<W extends AbstractFluidDisplayW
         return getBaseUnitSiPrefix().stringSymbol + getBaseUnit();
     }
 
+    /**
+     * @return the explicitly set unit, or the fluid unit configured in GTNHLib (mB or L) if none was set
+     */
     public String getBaseUnit() {
-        return this.unit;
+        return this.unit != null ? this.unit : NumberFormatUtil.getFluidUnit();
     }
 
     public SIPrefix getBaseUnitSiPrefix() {

--- a/src/main/java/com/cleanroommc/modularui/widgets/slot/FluidSlot.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/slot/FluidSlot.java
@@ -60,7 +60,7 @@ public class FluidSlot extends AbstractFluidDisplayWidget<FluidSlot> implements 
         if (this.syncHandler.isPhantom()) {
             if (fluid != null) {
                 if (this.syncHandler.controlsAmount()) {
-                    tooltip.addLine(IKey.lang("modularui2.fluid.phantom.amount", formatFluidTooltipAmount(fluid.amount), getBaseUnit()));
+                    tooltip.addLine(IKey.lang("modularui2.fluid.phantom.amount", formatFluidTooltipAmount(fluid.amount), getUnit()));
                 }
                 addAdditionalFluidInfo(tooltip, fluid);
             } else {
@@ -73,7 +73,7 @@ public class FluidSlot extends AbstractFluidDisplayWidget<FluidSlot> implements 
             }
         } else {
             if (fluid != null) {
-                tooltip.addLine(IKey.lang("modularui2.fluid.amount", formatFluidTooltipAmount(fluid.amount), formatFluidTooltipAmount(fluidTank.getCapacity()), getBaseUnit()));
+                tooltip.addLine(IKey.lang("modularui2.fluid.amount", formatFluidTooltipAmount(fluid.amount), formatFluidTooltipAmount(fluidTank.getCapacity()), getUnit()));
                 addAdditionalFluidInfo(tooltip, fluid);
             } else {
                 tooltip.addLine(IKey.lang("modularui2.fluid.empty"));

--- a/src/main/java/com/cleanroommc/modularui/widgets/slot/FluidSlot.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/slot/FluidSlot.java
@@ -102,7 +102,6 @@ public class FluidSlot extends AbstractFluidDisplayWidget<FluidSlot> implements 
 
     public String formatFluidTooltipAmount(double amount) {
         // the tooltip show the full number
-        // 1.7.10 hardcoded to use UNIT_LITER for now, so no milli-buckets.
         return TOOLTIP_FORMAT.format(amount);
     }
 


### PR DESCRIPTION
## Summary
Fluid slots always labelled amounts and capacities as L, ignoring the useForgeFluidMillibuckets option GTNHLib already exposes, so the setting had no effect on any GUI built on ModularUI2.

The unit now falls back to NumberFormatUtil.getFluidUnit() when a widget does not set one explicitly. Calls to fluidUnit() still override it, and UNIT_LITER/UNIT_BUCKET are unchanged.

https://discord.com/channels/181078474394566657/465207956745486336/1456155245708312812

## Checklist
- [ ] I have tested this PR in DevEnv
- [X] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
